### PR TITLE
prevent open file handles leak. fixes #9

### DIFF
--- a/src/main/java/org/nlpcn/es4sql/SearchDao.java
+++ b/src/main/java/org/nlpcn/es4sql/SearchDao.java
@@ -60,8 +60,6 @@ public class SearchDao {
 
 		Query query = null;
 
-		Client client = new TransportClient();
-
 		if (select.isAgg) {
 			query = new AggregationQuery(client, select);
 		} else {


### PR DESCRIPTION
prevent open file handles leak. by using original Client object instead of creating new TransportClient for each search.
