### PR TITLE
Set size to default of 100 when no limit specified.

### DIFF
--- a/src/main/java/org/nlpcn/es4sql/parse/SqlParser.java
+++ b/src/main/java/org/nlpcn/es4sql/parse/SqlParser.java
@@ -36,6 +36,9 @@ import org.durid.sql.dialect.mysql.ast.statement.MySqlSelectQueryBlock.Limit;
  */
 public class SqlParser {
 
+    private static final int DEFAULT_ROW_COUNT = 100;
+
+
 	public SqlParser() {
 	};
 
@@ -196,13 +199,14 @@ public class SqlParser {
 		Limit limit = query.getLimit();
 
 		if (limit == null) {
-			return;
-		}
+            select.setRowCount(DEFAULT_ROW_COUNT);
+        }
+        else {
+            select.setRowCount(Integer.parseInt(limit.getRowCount().toString()));
 
-		select.setRowCount(Integer.parseInt(limit.getRowCount().toString()));
-
-		if (limit.getOffset() != null)
-			select.setOffset(Integer.parseInt(limit.getOffset().toString()));
+            if (limit.getOffset() != null)
+                select.setOffset(Integer.parseInt(limit.getOffset().toString()));
+        }
 	}
 
 	private void findFrom(MySqlSelectQueryBlock query, Select select) {


### PR DESCRIPTION
When no limit specified, we end up with query with Integer.MAX_VALUE as size. 
This behavior will overload the elasticsearch cluster in common cases when limit forgotten.
This fix set the size to default of 100 when limit has not been specified.

For fetching the entire data scan and scroll should be used instead of classic from and size.
