### PR TITLE
Add LIKE query support

### DIFF
--- a/src/main/java/org/nlpcn/es4sql/query/maker/Maker.java
+++ b/src/main/java/org/nlpcn/es4sql/query/maker/Maker.java
@@ -137,6 +137,11 @@ public abstract class Maker {
 					x = FilterBuilders.termFilter(name, value);
 				break;
 			}
+		case LIKE:
+			String queryStr = ((String) value).replace('%', '*').replace('_', '?');
+			WildcardQueryBuilder wildcardQuery = QueryBuilders.wildcardQuery(name, queryStr);
+			x = isQuery ? wildcardQuery : FilterBuilders.queryFilter(wildcardQuery);
+			break;
 		case GT:
 			if (isQuery)
 				x = QueryBuilders.rangeQuery(name).gt(value);


### PR DESCRIPTION
Add LIKE query support.
use % to match any character sequance.
use _ to match any single character.

for example:
SELECT \* FROM myindex WHERE message LIKE '%llo wor_d'
