### PR TITLE
Added support for parsing an ODBC Literal Escape Sequence. Created Unit ...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jdk:
 
 
 before_install:
-  - wget https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.4.1.deb && sudo dpkg -i --force-confnew elasticsearch-1.4.1.deb --no-check-certificate
+  - wget https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.4.1.deb && sudo dpkg -i --force-confnew elasticsearch-1.4.1.deb
 
 services:
   - elasticsearch

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jdk:
 
 
 before_install:
-  - wget https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.4.1.deb && sudo dpkg -i --force-confnew elasticsearch-1.4.1.deb
+  - wget https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.4.1.deb && sudo dpkg -i --force-confnew elasticsearch-1.4.1.deb --no-check-certificate
 
 services:
   - elasticsearch

--- a/src/main/java/org/durid/sql/ast/expr/SQLOdbcExpr.java
+++ b/src/main/java/org/durid/sql/ast/expr/SQLOdbcExpr.java
@@ -1,0 +1,51 @@
+package org.durid.sql.ast.expr;
+
+/**
+ * Created by jheimbouch on 3/17/15.
+ */
+/*
+ * Copyright 1999-2011 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.durid.sql.visitor.SQLASTVisitor;
+
+public class SQLOdbcExpr extends SQLCharExpr {
+
+    private static final long serialVersionUID = 1L;
+
+    public SQLOdbcExpr(){
+
+    }
+
+    public SQLOdbcExpr(String text){
+        super(text);
+    }
+
+    @Override
+    public void output(StringBuffer buf) {
+        if ((this.text == null) || (this.text.length() == 0)) {
+            buf.append("NULL");
+        } else {
+            buf.append("{ts '");
+            buf.append(this.text.replaceAll("'", "''"));
+            buf.append("'}");
+        }
+    }
+
+    protected void accept0(SQLASTVisitor visitor) {
+        visitor.visit(this);
+        visitor.endVisit(this);
+    }
+}

--- a/src/main/java/org/durid/sql/ast/expr/SQLOdbcExpr.java
+++ b/src/main/java/org/durid/sql/ast/expr/SQLOdbcExpr.java
@@ -44,6 +44,15 @@ public class SQLOdbcExpr extends SQLCharExpr {
         }
     }
 
+    @Override
+    public String getText() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{ts '");
+        sb.append(this.text);
+        sb.append("'}");
+        return sb.toString();
+    }
+
     protected void accept0(SQLASTVisitor visitor) {
         visitor.visit(this);
         visitor.endVisit(this);

--- a/src/main/java/org/durid/sql/parser/SQLExprParser.java
+++ b/src/main/java/org/durid/sql/parser/SQLExprParser.java
@@ -150,7 +150,7 @@ public class SQLExprParser extends SQLParser {
                 tokenValue.add(lexer.token().name());
                 lexer.nextToken();
                 boolean foundRBrace = false;
-                if(lexer.stringVal().equals(Token.TS)){
+                if(lexer.stringVal().equals(Token.TS.name)){
                     String current = lexer.stringVal();
                     do {
                         tokens.add(lexer.token());
@@ -171,6 +171,8 @@ public class SQLExprParser extends SQLParser {
                     }else{
                         throw new ParserException("Error. Unable to find closing RBRACE");
                     }
+                }else{
+                    throw new ParserException("Error. Unable to parse ODBC Literal Timestamp");
                 }
                 break;
             case INSERT:

--- a/src/main/java/org/durid/sql/parser/SQLExprParser.java
+++ b/src/main/java/org/durid/sql/parser/SQLExprParser.java
@@ -28,36 +28,7 @@ import org.durid.sql.ast.SQLName;
 import org.durid.sql.ast.SQLOrderBy;
 import org.durid.sql.ast.SQLOrderingSpecification;
 import org.durid.sql.ast.SQLOver;
-import org.durid.sql.ast.expr.SQLAggregateExpr;
-import org.durid.sql.ast.expr.SQLAllColumnExpr;
-import org.durid.sql.ast.expr.SQLAllExpr;
-import org.durid.sql.ast.expr.SQLAnyExpr;
-import org.durid.sql.ast.expr.SQLBetweenExpr;
-import org.durid.sql.ast.expr.SQLBinaryOpExpr;
-import org.durid.sql.ast.expr.SQLBinaryOperator;
-import org.durid.sql.ast.expr.SQLCaseExpr;
-import org.durid.sql.ast.expr.SQLCastExpr;
-import org.durid.sql.ast.expr.SQLCharExpr;
-import org.durid.sql.ast.expr.SQLCurrentOfCursorExpr;
-import org.durid.sql.ast.expr.SQLDefaultExpr;
-import org.durid.sql.ast.expr.SQLExistsExpr;
-import org.durid.sql.ast.expr.SQLHexExpr;
-import org.durid.sql.ast.expr.SQLIdentifierExpr;
-import org.durid.sql.ast.expr.SQLInListExpr;
-import org.durid.sql.ast.expr.SQLInSubQueryExpr;
-import org.durid.sql.ast.expr.SQLIntegerExpr;
-import org.durid.sql.ast.expr.SQLListExpr;
-import org.durid.sql.ast.expr.SQLMethodInvokeExpr;
-import org.durid.sql.ast.expr.SQLNCharExpr;
-import org.durid.sql.ast.expr.SQLNotExpr;
-import org.durid.sql.ast.expr.SQLNullExpr;
-import org.durid.sql.ast.expr.SQLNumberExpr;
-import org.durid.sql.ast.expr.SQLPropertyExpr;
-import org.durid.sql.ast.expr.SQLQueryExpr;
-import org.durid.sql.ast.expr.SQLSomeExpr;
-import org.durid.sql.ast.expr.SQLUnaryExpr;
-import org.durid.sql.ast.expr.SQLUnaryOperator;
-import org.durid.sql.ast.expr.SQLVariantRefExpr;
+import org.durid.sql.ast.expr.*;
 import org.durid.sql.ast.statement.NotNullConstraint;
 import org.durid.sql.ast.statement.SQLAssignItem;
 import org.durid.sql.ast.statement.SQLCharactorDataType;
@@ -65,6 +36,8 @@ import org.durid.sql.ast.statement.SQLColumnDefinition;
 import org.durid.sql.ast.statement.SQLPrimaryKey;
 import org.durid.sql.ast.statement.SQLSelect;
 import org.durid.sql.ast.statement.SQLSelectOrderByItem;
+
+import javax.swing.text.html.parser.Parser;
 
 public class SQLExprParser extends SQLParser {
 
@@ -169,6 +142,36 @@ public class SQLExprParser extends SQLParser {
                     sqlExpr = listExpr;
                 }
                 accept(Token.RPAREN);
+                break;
+            case LBRACE:
+                List<Token> tokens = new ArrayList<>();
+                List<String> tokenValue = new ArrayList<>();
+                tokens.add(lexer.token());
+                tokenValue.add(lexer.token().name());
+                lexer.nextToken();
+                boolean foundRBrace = false;
+                if(lexer.stringVal().equals(Token.TS)){
+                    String current = lexer.stringVal();
+                    do {
+                        tokens.add(lexer.token());
+                        tokenValue.add(lexer.token().name());
+                        System.out.println(lexer.stringVal());
+                        if(current.equals(tok.RBRACE.name())){
+                            foundRBrace = true;
+                            break;
+                        }
+                        lexer.nextToken();
+                        current = lexer.token().name();
+                    }while(!foundRBrace && !current.trim().equals(""));
+
+                    if(foundRBrace){
+                        SQLCharExpr sdle = new SQLCharExpr(lexer.stringVal());
+                        sqlExpr = sdle;
+                        accept(Token.RBRACE);
+                    }else{
+                        throw new ParserException("Error. Unable to find closing RBRACE");
+                    }
+                }
                 break;
             case INSERT:
                 lexer.nextToken();

--- a/src/main/java/org/durid/sql/parser/SQLExprParser.java
+++ b/src/main/java/org/durid/sql/parser/SQLExprParser.java
@@ -37,8 +37,6 @@ import org.durid.sql.ast.statement.SQLPrimaryKey;
 import org.durid.sql.ast.statement.SQLSelect;
 import org.durid.sql.ast.statement.SQLSelectOrderByItem;
 
-import javax.swing.text.html.parser.Parser;
-
 public class SQLExprParser extends SQLParser {
 
     public SQLExprParser(String sql){
@@ -144,18 +142,11 @@ public class SQLExprParser extends SQLParser {
                 accept(Token.RPAREN);
                 break;
             case LBRACE:
-                List<Token> tokens = new ArrayList<>();
-                List<String> tokenValue = new ArrayList<>();
-                tokens.add(lexer.token());
-                tokenValue.add(lexer.token().name());
                 lexer.nextToken();
                 boolean foundRBrace = false;
                 if(lexer.stringVal().equals(Token.TS.name)){
                     String current = lexer.stringVal();
                     do {
-                        tokens.add(lexer.token());
-                        tokenValue.add(lexer.token().name());
-                        System.out.println(lexer.stringVal());
                         if(current.equals(tok.RBRACE.name())){
                             foundRBrace = true;
                             break;
@@ -165,7 +156,7 @@ public class SQLExprParser extends SQLParser {
                     }while(!foundRBrace && !current.trim().equals(""));
 
                     if(foundRBrace){
-                        SQLCharExpr sdle = new SQLCharExpr(lexer.stringVal());
+                        SQLOdbcExpr sdle = new SQLOdbcExpr(lexer.stringVal());
                         sqlExpr = sdle;
                         accept(Token.RBRACE);
                     }else{

--- a/src/main/java/org/durid/sql/parser/Token.java
+++ b/src/main/java/org/durid/sql/parser/Token.java
@@ -227,7 +227,8 @@ public enum Token {
     PERCENT("%"), 
     LTLT("<<"), 
     GTGT(">>"),
-    MONKEYS_AT("@");
+    MONKEYS_AT("@"),
+    TS("ts");
 
     public final String name;
 

--- a/src/main/java/org/durid/sql/visitor/SQLASTVisitor.java
+++ b/src/main/java/org/durid/sql/visitor/SQLASTVisitor.java
@@ -20,38 +20,7 @@ import org.durid.sql.ast.SQLDataType;
 import org.durid.sql.ast.SQLObject;
 import org.durid.sql.ast.SQLOrderBy;
 import org.durid.sql.ast.SQLOver;
-import org.durid.sql.ast.expr.SQLAggregateExpr;
-import org.durid.sql.ast.expr.SQLAllColumnExpr;
-import org.durid.sql.ast.expr.SQLAllExpr;
-import org.durid.sql.ast.expr.SQLAnyExpr;
-import org.durid.sql.ast.expr.SQLBetweenExpr;
-import org.durid.sql.ast.expr.SQLBinaryOpExpr;
-import org.durid.sql.ast.expr.SQLBitStringLiteralExpr;
-import org.durid.sql.ast.expr.SQLCaseExpr;
-import org.durid.sql.ast.expr.SQLCastExpr;
-import org.durid.sql.ast.expr.SQLCharExpr;
-import org.durid.sql.ast.expr.SQLCurrentOfCursorExpr;
-import org.durid.sql.ast.expr.SQLDateLiteralExpr;
-import org.durid.sql.ast.expr.SQLDefaultExpr;
-import org.durid.sql.ast.expr.SQLExistsExpr;
-import org.durid.sql.ast.expr.SQLHexExpr;
-import org.durid.sql.ast.expr.SQLHexStringLiteralExpr;
-import org.durid.sql.ast.expr.SQLIdentifierExpr;
-import org.durid.sql.ast.expr.SQLInListExpr;
-import org.durid.sql.ast.expr.SQLInSubQueryExpr;
-import org.durid.sql.ast.expr.SQLIntegerExpr;
-import org.durid.sql.ast.expr.SQLIntervalLiteralExpr;
-import org.durid.sql.ast.expr.SQLListExpr;
-import org.durid.sql.ast.expr.SQLMethodInvokeExpr;
-import org.durid.sql.ast.expr.SQLNCharExpr;
-import org.durid.sql.ast.expr.SQLNotExpr;
-import org.durid.sql.ast.expr.SQLNullExpr;
-import org.durid.sql.ast.expr.SQLNumberExpr;
-import org.durid.sql.ast.expr.SQLPropertyExpr;
-import org.durid.sql.ast.expr.SQLQueryExpr;
-import org.durid.sql.ast.expr.SQLSomeExpr;
-import org.durid.sql.ast.expr.SQLUnaryExpr;
-import org.durid.sql.ast.expr.SQLVariantRefExpr;
+import org.durid.sql.ast.expr.*;
 import org.durid.sql.ast.statement.NotNullConstraint;
 import org.durid.sql.ast.statement.SQLAlterTableAddColumn;
 import org.durid.sql.ast.statement.SQLAlterTableAddPrimaryKey;
@@ -98,6 +67,8 @@ public interface SQLASTVisitor {
 
     void endVisit(SQLBinaryOpExpr x);
 
+    void endVisit(SQLOdbcExpr x);
+
     void endVisit(SQLCaseExpr x);
 
     void endVisit(SQLCaseExpr.Item x);
@@ -137,6 +108,8 @@ public interface SQLASTVisitor {
     boolean visit(SQLBetweenExpr x);
 
     boolean visit(SQLBinaryOpExpr x);
+
+    boolean visit(SQLOdbcExpr x);
 
     boolean visit(SQLCaseExpr x);
 

--- a/src/main/java/org/durid/sql/visitor/SQLASTVisitorAdapter.java
+++ b/src/main/java/org/durid/sql/visitor/SQLASTVisitorAdapter.java
@@ -20,38 +20,7 @@ import org.durid.sql.ast.SQLDataType;
 import org.durid.sql.ast.SQLObject;
 import org.durid.sql.ast.SQLOrderBy;
 import org.durid.sql.ast.SQLOver;
-import org.durid.sql.ast.expr.SQLAggregateExpr;
-import org.durid.sql.ast.expr.SQLAllColumnExpr;
-import org.durid.sql.ast.expr.SQLAllExpr;
-import org.durid.sql.ast.expr.SQLAnyExpr;
-import org.durid.sql.ast.expr.SQLBetweenExpr;
-import org.durid.sql.ast.expr.SQLBinaryOpExpr;
-import org.durid.sql.ast.expr.SQLBitStringLiteralExpr;
-import org.durid.sql.ast.expr.SQLCaseExpr;
-import org.durid.sql.ast.expr.SQLCastExpr;
-import org.durid.sql.ast.expr.SQLCharExpr;
-import org.durid.sql.ast.expr.SQLCurrentOfCursorExpr;
-import org.durid.sql.ast.expr.SQLDateLiteralExpr;
-import org.durid.sql.ast.expr.SQLDefaultExpr;
-import org.durid.sql.ast.expr.SQLExistsExpr;
-import org.durid.sql.ast.expr.SQLHexExpr;
-import org.durid.sql.ast.expr.SQLHexStringLiteralExpr;
-import org.durid.sql.ast.expr.SQLIdentifierExpr;
-import org.durid.sql.ast.expr.SQLInListExpr;
-import org.durid.sql.ast.expr.SQLInSubQueryExpr;
-import org.durid.sql.ast.expr.SQLIntegerExpr;
-import org.durid.sql.ast.expr.SQLIntervalLiteralExpr;
-import org.durid.sql.ast.expr.SQLListExpr;
-import org.durid.sql.ast.expr.SQLMethodInvokeExpr;
-import org.durid.sql.ast.expr.SQLNCharExpr;
-import org.durid.sql.ast.expr.SQLNotExpr;
-import org.durid.sql.ast.expr.SQLNullExpr;
-import org.durid.sql.ast.expr.SQLNumberExpr;
-import org.durid.sql.ast.expr.SQLPropertyExpr;
-import org.durid.sql.ast.expr.SQLQueryExpr;
-import org.durid.sql.ast.expr.SQLSomeExpr;
-import org.durid.sql.ast.expr.SQLUnaryExpr;
-import org.durid.sql.ast.expr.SQLVariantRefExpr;
+import org.durid.sql.ast.expr.*;
 import org.durid.sql.ast.statement.NotNullConstraint;
 import org.durid.sql.ast.statement.SQLAlterTableAddColumn;
 import org.durid.sql.ast.statement.SQLAlterTableAddPrimaryKey;
@@ -100,6 +69,9 @@ public class SQLASTVisitorAdapter implements SQLASTVisitor {
     }
 
     public void endVisit(SQLBinaryOpExpr x) {
+    }
+
+    public void endVisit(SQLOdbcExpr x) {
     }
 
     public void endVisit(SQLCaseExpr x) {
@@ -164,6 +136,8 @@ public class SQLASTVisitorAdapter implements SQLASTVisitor {
     public boolean visit(SQLBinaryOpExpr x) {
         return true;
     }
+
+    public boolean visit(SQLOdbcExpr x) { return false; }
 
     public boolean visit(SQLCaseExpr x) {
         return true;

--- a/src/test/java/org/nlpcn/es4sql/MainTestSuite.java
+++ b/src/test/java/org/nlpcn/es4sql/MainTestSuite.java
@@ -5,6 +5,7 @@ package org.nlpcn.es4sql;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequestBuilder;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexResponse;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.delete.DeleteRequestBuilder;
@@ -51,6 +52,10 @@ public class MainTestSuite {
 		loadBulk("src/test/resources/accounts.json");
 		loadBulk("src/test/resources/phrases.json");
 		loadBulk("src/test/resources/online.json");
+
+        prepareOdbcIndex();
+        loadBulk("src/test/resources/odbc-date-formats.json");
+
 
 
 		searchDao = new SearchDao(client);
@@ -114,6 +119,23 @@ public class MainTestSuite {
 		}
 	}
 
+    public static void prepareOdbcIndex(){
+        String dataMapping = "{\n" +
+                "\t\"odbc\" :{\n" +
+                "\t\t\"properties\":{\n" +
+                "\t\t\t\"insert_time\":{\n" +
+                "\t\t\t\t\"type\":\"date\",\n" +
+                "\t\t\t\t\"format\": \"{'ts' ''yyyy-MM-dd HH:mm:ss.SSS''}\"\n" +
+                "\t\t\t},\n" +
+                "\t\t\t\"docCount\":{\n" +
+                "\t\t\t\t\"type\":\"string\"\n" +
+                "\t\t\t}\n" +
+                "\t\t}\n" +
+                "\t}\n" +
+                "}";
+
+        client.admin().indices().preparePutMapping(TEST_INDEX).setType("odbc").setSource(dataMapping).execute().actionGet();
+    }
 
 	public static SearchDao getSearchDao() {
 		return searchDao;
@@ -128,7 +150,7 @@ public class MainTestSuite {
 		String port = System.getenv("ES_TEST_PORT");
 
 		if(host == null) {
-			host = "localhost";
+			host = "10.1.1.44";
 			System.out.println("ES_TEST_HOST enviroment variable does not exist. choose default 'localhost'");
 		}
 

--- a/src/test/java/org/nlpcn/es4sql/MainTestSuite.java
+++ b/src/test/java/org/nlpcn/es4sql/MainTestSuite.java
@@ -150,7 +150,7 @@ public class MainTestSuite {
 		String port = System.getenv("ES_TEST_PORT");
 
 		if(host == null) {
-			host = "10.1.1.44";
+			host = "localhost";
 			System.out.println("ES_TEST_HOST enviroment variable does not exist. choose default 'localhost'");
 		}
 

--- a/src/test/java/org/nlpcn/es4sql/QueryTest.java
+++ b/src/test/java/org/nlpcn/es4sql/QueryTest.java
@@ -301,7 +301,7 @@ public class QueryTest {
             Map<String, Object> source = hit.getSource();
             DateTime insertTime = formatter.parseDateTime((String) source.get("insert_time"));
 
-            String errorMessage = String.format("insert_time must be smaller then 2015-01-15. found: %s", insertTime);
+            String errorMessage = String.format("insert_time must be smaller then 2015-03-15. found: %s", insertTime);
             Assert.assertTrue(errorMessage, insertTime.isBefore(dateToCompare));
         }
     }

--- a/src/test/java/org/nlpcn/es4sql/QueryTest.java
+++ b/src/test/java/org/nlpcn/es4sql/QueryTest.java
@@ -290,6 +290,22 @@ public class QueryTest {
 		}
 	}
 
+    @Test
+    public void dateSearchBraces() throws IOException, SqlParseException, SQLFeatureNotSupportedException, ParseException {
+        DateTimeFormatter formatter = DateTimeFormat.forPattern(DATE_FORMAT);
+        DateTime dateToCompare = new DateTime(2014, 8, 18, 0, 0, 0);
+
+        SearchHits response = query(String.format("SELECT insert_time FROM %s/online WHERE insert_time < {ts '2014-08-18'}", TEST_INDEX));
+        SearchHit[] hits = response.getHits();
+        for(SearchHit hit : hits) {
+            Map<String, Object> source = hit.getSource();
+            DateTime insertTime = formatter.parseDateTime((String) source.get("insert_time"));
+
+            String errorMessage = String.format("insert_time must be smaller then 2014-08-18. found: %s", insertTime);
+            Assert.assertTrue(errorMessage, insertTime.isBefore(dateToCompare));
+        }
+    }
+
 
 	@Test
 	public void dateBetweenSearch() throws IOException, SqlParseException, SQLFeatureNotSupportedException {

--- a/src/test/java/org/nlpcn/es4sql/QueryTest.java
+++ b/src/test/java/org/nlpcn/es4sql/QueryTest.java
@@ -293,15 +293,15 @@ public class QueryTest {
     @Test
     public void dateSearchBraces() throws IOException, SqlParseException, SQLFeatureNotSupportedException, ParseException {
         DateTimeFormatter formatter = DateTimeFormat.forPattern(DATE_FORMAT);
-        DateTime dateToCompare = new DateTime(2014, 8, 18, 0, 0, 0);
+        DateTime dateToCompare = new DateTime(2015, 1, 15, 0, 0, 0);
 
-        SearchHits response = query(String.format("SELECT insert_time FROM %s/online WHERE insert_time < {ts '2014-08-18'}", TEST_INDEX));
+        SearchHits response = query(String.format("SELECT insert_time FROM %s/odbc WHERE insert_time < {ts '2015-03-15 00:00:00.000'}", TEST_INDEX));
         SearchHit[] hits = response.getHits();
         for(SearchHit hit : hits) {
             Map<String, Object> source = hit.getSource();
             DateTime insertTime = formatter.parseDateTime((String) source.get("insert_time"));
 
-            String errorMessage = String.format("insert_time must be smaller then 2014-08-18. found: %s", insertTime);
+            String errorMessage = String.format("insert_time must be smaller then 2015-01-15. found: %s", insertTime);
             Assert.assertTrue(errorMessage, insertTime.isBefore(dateToCompare));
         }
     }

--- a/src/test/resources/odbc-date-formats.json
+++ b/src/test/resources/odbc-date-formats.json
@@ -1,0 +1,20 @@
+{"index":{"_type": "odbc"}}
+{"insert_time":"{ts '2015-03-16 13:27:33.953'}", "docCount":"1"}
+{"index":{"_type": "odbc"}}
+{"insert_time":"{ts '2015-03-15 13:27:33.953'}", "docCount":"2"}
+{"index":{"_type": "odbc"}}
+{"insert_time":"{ts '2015-03-14 13:27:33.953'}", "docCount":"3"}
+{"index":{"_type": "odbc"}}
+{"insert_time":"{ts '2015-03-13 13:27:33.954'}", "docCount":"4"}
+{"index":{"_type": "odbc"}}
+{"insert_time":"{ts '2015-03-12 13:27:33.954'}", "docCount":"5"}
+{"index":{"_type": "odbc"}}
+{"insert_time":"{ts '2015-03-11 13:27:33.955'}", "docCount":"6"}
+{"index":{"_type": "odbc"}}
+{"insert_time":"{ts '2015-03-10 13:27:33.955'}", "docCount":"7"}
+{"index":{"_type": "odbc"}}
+{"insert_time":"{ts '2015-03-09 13:27:33.955'}", "docCount":"8"}
+{"index":{"_type": "odbc"}}
+{"insert_time":"{ts '2015-03-08 13:27:33.956'}", "docCount":"9"}
+{"index":{"_type": "odbc"}}
+{"insert_time":"{ts '2015-03-07 13:27:33.956'}", "docCount":"10"}


### PR DESCRIPTION
Hello, in regards to Issue https://github.com/NLPchina/elasticsearch-sql/issues/45, I have implemented a fix to allow parsing for an ODBC Literal Escape Sequence. Link to MSDN here: https://msdn.microsoft.com/en-gb/library/windows/desktop/ms712360(v=vs.85).aspx

I wrote a unit test, that passed, and ensured all others did as well.