### PR TITLE
Fix for Operator precedence (A or B) and (C or D)

### DIFF
--- a/src/main/java/org/nlpcn/es4sql/parse/SqlParser.java
+++ b/src/main/java/org/nlpcn/es4sql/parse/SqlParser.java
@@ -103,7 +103,7 @@ public class SqlParser {
 		if (isCond(sub)) {
 			explanCond(expr.operator.name, sub, where);
 		} else {
-			if (sub.operator.priority < expr.operator.priority) {
+			if (sub.operator.priority > expr.operator.priority) {
 				Where subWhere = new Where(expr.getOperator().name);
 				where.addWhere(subWhere);
 				parseWhere(sub, subWhere);

--- a/src/test/java/org/nlpcn/es4sql/QueryTest.java
+++ b/src/test/java/org/nlpcn/es4sql/QueryTest.java
@@ -404,6 +404,24 @@ public class QueryTest {
 		Assert.assertTrue("The list is not ordered descending", sortedAges.equals(ages));
 	}
 
+    @Test
+    public void testMultipartWhere() throws IOException, SqlParseException, SQLFeatureNotSupportedException{
+        SearchHits response = query(String.format("SELECT * FROM %s/account WHERE (firstname LIKE 'opal' OR firstname like 'rodriquez') AND (state like 'oh' OR state like 'hi')", TEST_INDEX));
+        Assert.assertEquals(2, response.getTotalHits());
+    }
+
+    @Test
+    public void testMultipartWhere2() throws IOException, SqlParseException, SQLFeatureNotSupportedException{
+        SearchHits response = query(String.format("SELECT * FROM %s/account where ((account_number > 200 and account_number < 300) or gender like 'm') and (state like 'hi' or address like 'avenue')", TEST_INDEX));
+        Assert.assertEquals(11, response.getTotalHits());
+    }
+
+    @Test
+    public void testMultipartWhere3() throws IOException, SqlParseException, SQLFeatureNotSupportedException{
+        SearchHits response = query(String.format("SELECT * FROM %s/account where ((account_number > 25 and account_number < 75) and age >35 ) and (state like 'md' or (address like 'avenue' or address like 'street'))", TEST_INDEX));
+        Assert.assertEquals(7, response.getTotalHits());
+    }
+
 	private SearchHits query(String query) throws SqlParseException, SQLFeatureNotSupportedException, SQLFeatureNotSupportedException {
 		SearchDao searchDao = MainTestSuite.getSearchDao();
 		SearchRequestBuilder select = (SearchRequestBuilder)searchDao.explain(query);


### PR DESCRIPTION
Fixed bug where priority of expression operator was being treated higher than the sub operator.

Added unit tests to ensure change works.

This fixes issue #44 operator precedence. The correct elastic is now generated for (A or B) and (C or D)