### PR TITLE
 ( ( A and B ) or C ) and ( D or E ) case is converted to ( ( A and B) and C ) and ( D or E ). that's wrong

### DIFF
--- a/src/main/java/org/nlpcn/es4sql/parse/SqlParser.java
+++ b/src/main/java/org/nlpcn/es4sql/parse/SqlParser.java
@@ -103,7 +103,7 @@ public class SqlParser {
 		if (isCond(sub)) {
 			explanCond(expr.operator.name, sub, where);
 		} else {
-			if (sub.operator.priority > expr.operator.priority) {
+			if (sub.operator.priority != expr.operator.priority) {
 				Where subWhere = new Where(expr.getOperator().name);
 				where.addWhere(subWhere);
 				parseWhere(sub, subWhere);

--- a/src/test/java/org/nlpcn/es4sql/QueryTest.java
+++ b/src/test/java/org/nlpcn/es4sql/QueryTest.java
@@ -413,7 +413,7 @@ public class QueryTest {
     @Test
     public void testMultipartWhere2() throws IOException, SqlParseException, SQLFeatureNotSupportedException{
         SearchHits response = query(String.format("SELECT * FROM %s/account where ((account_number > 200 and account_number < 300) or gender like 'm') and (state like 'hi' or address like 'avenue')", TEST_INDEX));
-        Assert.assertEquals(11, response.getTotalHits());
+        Assert.assertEquals(127, response.getTotalHits());
     }
 
     @Test


### PR DESCRIPTION
unit test(testMultipartWhere2)'s converted query is somethting wrong

testMultipartWhere2 => ( ( A and B ) or C ) and ( D or E ) case is converted to ( ( A and B) and C ) and ( D or E ). that's wrong

I fixed this bug.