### PR TITLE
Fixed a bug with multiple escaped single quotes in a string

### DIFF
--- a/src/main/java/org/durid/sql/dialect/mysql/parser/MySqlLexer.java
+++ b/src/main/java/org/durid/sql/dialect/mysql/parser/MySqlLexer.java
@@ -264,9 +264,11 @@ public class MySqlLexer extends Lexer {
                     token = LITERAL_CHARS;
                     break;
                 } else {
-                    initBuff(bufPos);
-                    arraycopy(mark + 1, buf, 0, bufPos);
-                    hasSpecial = true;
+                    if (!hasSpecial) {
+                        initBuff(bufPos);
+                        arraycopy(mark + 1, buf, 0, bufPos);
+                        hasSpecial = true;
+                    }
                     putChar('\'');
                     continue;
                 }


### PR DESCRIPTION
Fixed a bug with scanning strings when there is more than one escaped single quote.

For example this would break, Where fullName LIKE 'Clark ''Superman'' Kent'.

The issue in the code was that it wasn't checking to see if it was already parsing special characters. So it was re-initializing the buff and trashing all previous special characters that were handled.