### PR TITLE
Fixed a bug where not's would not evaluate properly.

### DIFF
--- a/src/main/java/org/nlpcn/es4sql/query/maker/FilterMaker.java
+++ b/src/main/java/org/nlpcn/es4sql/query/maker/FilterMaker.java
@@ -19,6 +19,9 @@ public class FilterMaker extends Maker {
 	 */
 	public static BoolFilterBuilder explan(Where where) throws SqlParseException {
 		BoolFilterBuilder boolFilter = FilterBuilders.boolFilter();
+		while (where.getWheres().size() == 1) {
+			where = where.getWheres().getFirst();
+		}
 		new FilterMaker().explanWhere(boolFilter, where);
 		return boolFilter;
 	}

--- a/src/main/java/org/nlpcn/es4sql/query/maker/FilterMaker.java
+++ b/src/main/java/org/nlpcn/es4sql/query/maker/FilterMaker.java
@@ -28,9 +28,6 @@ public class FilterMaker extends Maker {
 	}
 
 	private void explanWhere(BoolFilterBuilder boolFilter, Where where) throws SqlParseException {
-		while (where.getWheres().size() == 1) {
-			where = where.getWheres().getFirst();
-		}
 		if (where instanceof Condition) {
 			addSubFilter(boolFilter, where, (BaseFilterBuilder) make((Condition) where));
 		} else {

--- a/src/test/java/org/nlpcn/es4sql/QueryTest.java
+++ b/src/test/java/org/nlpcn/es4sql/QueryTest.java
@@ -220,6 +220,25 @@ public class QueryTest {
 	}
 
 	@Test
+	public void doubleNotTest() throws IOException, SqlParseException, SQLFeatureNotSupportedException {
+		SearchHits response1 = query(String.format("SELECT * FROM %s/account WHERE not gender like 'm' and not gender like 'f'", TEST_INDEX));
+		Assert.assertEquals(0, response1.getTotalHits());
+
+		SearchHits response2 = query(String.format("SELECT * FROM %s/account WHERE not gender like 'm' and gender not like 'f'", TEST_INDEX));
+		Assert.assertEquals(0, response2.getTotalHits());
+
+		SearchHits response3 = query(String.format("SELECT * FROM %s/account WHERE gender not like 'm' and gender not like 'f'", TEST_INDEX));
+		Assert.assertEquals(0, response3.getTotalHits());
+
+		SearchHits response4 = query(String.format("SELECT * FROM %s/account WHERE gender like 'm' and not gender like 'f'", TEST_INDEX));
+		// assert there are results and they all have gender 'm'
+		Assert.assertNotEquals(0, response4.getTotalHits());
+		for (SearchHit hit : response4.getHits()) {
+			Assert.assertEquals("m", hit.getSource().get("gender").toString().toLowerCase());
+		}
+	}
+
+	@Test
 	public void limitTest() throws IOException, SqlParseException, SQLFeatureNotSupportedException {
 		SearchHits response = query(String.format("SELECT * FROM %s LIMIT 30", TEST_INDEX));
 		SearchHit[] hits = response.getHits();
@@ -346,8 +365,8 @@ public class QueryTest {
 			}
 		}
 	}
-	
-	
+
+
 	@Test
 	public void dateSearch() throws IOException, SqlParseException, SQLFeatureNotSupportedException, ParseException {
 		DateTimeFormatter formatter = DateTimeFormat.forPattern(DATE_FORMAT);
@@ -429,7 +448,7 @@ public class QueryTest {
 			assertThat(hit.getSource(), hasKey("insert_time"));
 		}
 	}
-	
+
 
 
 	@Test

--- a/src/test/resources/expectedOutput/search_spatial_explain.json
+++ b/src/test/resources/expectedOutput/search_spatial_explain.json
@@ -6,15 +6,19 @@
       "filter" : {
         "bool" : {
           "must" : {
-            "geo_shape" : {
-              "place" : {
-                "shape" : {
-                  "type" : "polygon",
-                  "coordinates" : [ [ [ 102.0, 2.0 ], [ 103.0, 2.0 ], [ 103.0, 3.0 ], [ 102.0, 3.0 ], [ 102.0, 2.0 ] ] ]
-                },
-                "relation" : "intersects"
-              },
-              "_name" : null
+            "bool" : {
+              "must" : {
+                "geo_shape" : {
+                  "place" : {
+                    "shape" : {
+                      "type" : "polygon",
+                      "coordinates" : [ [ [ 102.0, 2.0 ], [ 103.0, 2.0 ], [ 103.0, 3.0 ], [ 102.0, 3.0 ], [ 102.0, 2.0 ] ] ]
+                    },
+                    "relation" : "intersects"
+                  },
+                  "_name" : null
+                }
+              }
             }
           }
         }

--- a/src/test/resources/expectedOutput/search_spatial_explain.json
+++ b/src/test/resources/expectedOutput/search_spatial_explain.json
@@ -6,19 +6,15 @@
       "filter" : {
         "bool" : {
           "must" : {
-            "bool" : {
-              "must" : {
-                "geo_shape" : {
-                  "place" : {
-                    "shape" : {
-                      "type" : "polygon",
-                      "coordinates" : [ [ [ 102.0, 2.0 ], [ 103.0, 2.0 ], [ 103.0, 3.0 ], [ 102.0, 3.0 ], [ 102.0, 2.0 ] ] ]
-                    },
-                    "relation" : "intersects"
-                  },
-                  "_name" : null
-                }
-              }
+            "geo_shape" : {
+              "place" : {
+                "shape" : {
+                  "type" : "polygon",
+                  "coordinates" : [ [ [ 102.0, 2.0 ], [ 103.0, 2.0 ], [ 103.0, 3.0 ], [ 102.0, 3.0 ], [ 102.0, 2.0 ] ] ]
+                },
+                "relation" : "intersects"
+              },
+              "_name" : null
             }
           }
         }


### PR DESCRIPTION
Removed the loop to go to the last where if the where's only had a single sub where. This breaks the NOT where because its operator is important. The test shows that if the where's are skipped to the last where the AND (must) changes to a OR (should), which changes the result.
Added a test for the use case and updated the other test the change affected.