### PR TITLE
Corrected ordering search results with group by

### DIFF
--- a/src/main/java/org/nlpcn/es4sql/query/AggregationQueryAction.java
+++ b/src/main/java/org/nlpcn/es4sql/query/AggregationQueryAction.java
@@ -90,6 +90,8 @@ public class AggregationQueryAction extends QueryAction {
 						break;
 					case "KEY":
 						termsBuilder.order(Terms.Order.term(isASC(order)));
+						// add the sort to the request also so the results get sorted as well
+						request.addSort(order.getName(), SortOrder.valueOf(order.getType()));
 						break;
 					case "FIELD":
 						termsBuilder.order(Terms.Order.aggregation(order.getName(), isASC(order)));


### PR DESCRIPTION
Added the order by to be applied to the search results even if the order by is part of an aggregation.