### PR TITLE
Fixed double nots in 2.0.0 version.

### DIFF
--- a/src/main/java/org/nlpcn/es4sql/parse/SqlParser.java
+++ b/src/main/java/org/nlpcn/es4sql/parse/SqlParser.java
@@ -553,9 +553,8 @@ public class SqlParser {
 				cond.setOpear(cond.getOpear().negative());
 			} else {
 				negateWhere(sub);
-                sub.setConn(sub.getConn().negative());
 			}
-
+            sub.setConn(sub.getConn().negative());
 		}
 	}
 

--- a/src/main/java/org/nlpcn/es4sql/query/maker/QueryMaker.java
+++ b/src/main/java/org/nlpcn/es4sql/query/maker/QueryMaker.java
@@ -20,6 +20,9 @@ public class QueryMaker extends Maker {
 	 */
 	public static BoolQueryBuilder explan(Where where) throws SqlParseException {
 		BoolQueryBuilder boolQuery = QueryBuilders.boolQuery();
+		while (where.getWheres().size() == 1) {
+			where = where.getWheres().getFirst();
+		}
 		new QueryMaker().explanWhere(boolQuery, where);
 		return boolQuery;
 	}
@@ -29,9 +32,6 @@ public class QueryMaker extends Maker {
 	}
 
 	private void explanWhere(BoolQueryBuilder boolQuery, Where where) throws SqlParseException {
-		while (where.getWheres().size() == 1) {
-			where = where.getWheres().getFirst();
-		}
 		if (where instanceof Condition) {
 			addSubQuery(boolQuery, where, (QueryBuilder) make((Condition) where));
 		} else {

--- a/src/test/java/org/nlpcn/es4sql/QueryTest.java
+++ b/src/test/java/org/nlpcn/es4sql/QueryTest.java
@@ -1,24 +1,17 @@
 package org.nlpcn.es4sql;
 
-import com.alibaba.druid.sql.ast.SQLExpr;
-import com.alibaba.druid.sql.ast.expr.SQLQueryExpr;
-import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
-import org.elasticsearch.search.aggregations.support.format.ValueFormatter;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.junit.Assert;
 import org.junit.Test;
-import org.nlpcn.es4sql.domain.Select;
 import org.nlpcn.es4sql.exception.SqlParseException;
 import org.nlpcn.es4sql.query.SqlElasticSearchRequestBuilder;
 
-import javax.naming.directory.SearchControls;
 import java.io.IOException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.text.ParseException;
@@ -238,6 +231,9 @@ public class QueryTest {
 		for (SearchHit hit : response4.getHits()) {
 			Assert.assertEquals("m", hit.getSource().get("gender").toString().toLowerCase());
 		}
+
+		SearchHits response5 = query(String.format("SELECT * FROM %s/account WHERE NOT (gender = 'm' OR gender = 'f')", TEST_INDEX));
+		Assert.assertEquals(0, response5.getTotalHits());
 	}
 
 	@Test


### PR DESCRIPTION
 Had fixed this in FilterMaker but not in QueryMaker. Applied the same fix to QueryMaker.

Reverted the change to SqlParser to be what it is supposed to be.
Added another test to the double not test so both scenarios are tested now