### PR TITLE
I think this need precision_threshold offset.

### DIFF
--- a/src/main/java/org/nlpcn/es4sql/query/maker/AggMaker.java
+++ b/src/main/java/org/nlpcn/es4sql/query/maker/AggMaker.java
@@ -462,7 +462,8 @@ public class AggMaker {
 
 		// Cardinality is approximate DISTINCT.
 		if ("DISTINCT".equals(field.getOption())) {
-			return AggregationBuilders.cardinality(field.getAlias()).precisionThreshold(40000).field(field.getParams().get(0).value.toString());
+            Integer precision_threshold = field.getParams().size()>1 ? (Integer)(field.getParams().get(1).value)  : 40000;
+			return AggregationBuilders.cardinality(field.getAlias()).precisionThreshold(precision_threshold).field(field.getParams().get(0).value.toString());
 		}
 
 		String fieldName = field.getParams().get(0).value.toString();


### PR DESCRIPTION
I think this need precision_threshold offset. In my cluster, there is slow query problem with precision_threshold. With 40000, cardinality agg is too slow. So it will be good for this project.
In this code, you can use offset like this 'COUNT(DISTINCT foo, 4000)'