### PR TITLE
CSV export via REST API leads to NPE -> Bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Elasticsearch-SQL
 **2.2.0** [![2.2.0 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.2.0)](https://travis-ci.org/NLPchina/elasticsearch-sql)
 **2.2.1** [![2.2.1 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.2.1)](https://travis-ci.org/NLPchina/elasticsearch-sql)
 **2.3.0** [![2.3.0 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.3.0)](https://travis-ci.org/NLPchina/elasticsearch-sql)
+**2.3.1** [![2.3.1 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.3.1)](https://travis-ci.org/NLPchina/elasticsearch-sql)
 
 Query elasticsearch using familiar SQL syntax.
 You can also use ES functions in SQL.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Elasticsearch-SQL
 **2.1.2** [![2.1.2 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.1.2)](https://travis-ci.org/NLPchina/elasticsearch-sql)
 **2.2.0** [![2.2.0 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.2.0)](https://travis-ci.org/NLPchina/elasticsearch-sql)
 **2.2.1** [![2.2.1 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.2.1)](https://travis-ci.org/NLPchina/elasticsearch-sql)
+**2.3.0** [![2.3.0 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.3.0)](https://travis-ci.org/NLPchina/elasticsearch-sql)
 
 Query elasticsearch using familiar SQL syntax.
 You can also use ES functions in SQL.
@@ -35,6 +36,7 @@ Versions
 | 2.1.2                 | 2.1.2.0        | delete commands not supported  | elastic2.1.2 |
 | 2.2.0                 | 2.2.0.1        | delete commands not supported  | elastic2.2.0 |
 | 2.2.1                 | 2.2.1.0        | delete commands not supported  | elastic2.2.1 |
+| 2.3.0                 | 2.3.0.0        | delete commands not supported  | elastic2.3.0 |
 
 ### Elasticsearch 1.X
 ````
@@ -64,6 +66,11 @@ Versions
 ````
 ./bin/plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/2.2.1.0/elasticsearch-sql-2.2.1.0.zip 
 ````
+### Elasticsearch 2.3.0
+````
+./bin/plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/2.3.0.0/elasticsearch-sql-2.3.0.0.zip 
+````
+
 After doing this, you need to restart the Elasticsearch server. Otherwise you may get errors like `Invalid index name [sql], must not start with '']; ","status":400}`.
 
 ## Basic Usage

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Versions
 | 2.2.0                 | 2.2.0.1        | delete commands not supported  | elastic2.2.0 |
 | 2.2.1                 | 2.2.1.0        | delete commands not supported  | elastic2.2.1 |
 | 2.3.0                 | 2.3.0.0        | delete commands not supported  | elastic2.3.0 |
+| 2.3.1                 | 2.3.1.0        | delete commands not supported  | elastic2.3.1 |
 
 ### Elasticsearch 1.X
 ````
@@ -70,6 +71,10 @@ Versions
 ### Elasticsearch 2.3.0
 ````
 ./bin/plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/2.3.0.0/elasticsearch-sql-2.3.0.0.zip 
+````
+### Elasticsearch 2.3.1
+````
+./bin/plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/2.3.1.0/elasticsearch-sql-2.3.1.0.zip 
 ````
 
 After doing this, you need to restart the Elasticsearch server. Otherwise you may get errors like `Invalid index name [sql], must not start with '']; ","status":400}`.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Versions
 ````
 ./bin/plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/2.1.1.1/elasticsearch-sql-2.1.1.1.zip 
 ````
+### Elasticsearch 2.1.2
+````
+./bin/plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/2.1.2.0/elasticsearch-sql-2.1.2.0.zip 
+````
 ### Elasticsearch 2.2.0
 ````
 ./bin/plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/2.2.0.1/elasticsearch-sql-2.2.0.1.zip 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Elasticsearch-SQL
 **2.2.1** [![2.2.1 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.2.1)](https://travis-ci.org/NLPchina/elasticsearch-sql)
 **2.3.0** [![2.3.0 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.3.0)](https://travis-ci.org/NLPchina/elasticsearch-sql)
 **2.3.1** [![2.3.1 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.3.1)](https://travis-ci.org/NLPchina/elasticsearch-sql)
+**2.3.2** [![2.3.2 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.3.2)](https://travis-ci.org/NLPchina/elasticsearch-sql)
 
 Query elasticsearch using familiar SQL syntax.
 You can also use ES functions in SQL.
@@ -39,6 +40,7 @@ Versions
 | 2.2.1                 | 2.2.1.0        | delete commands not supported  | elastic2.2.1 |
 | 2.3.0                 | 2.3.0.0        | delete commands not supported  | elastic2.3.0 |
 | 2.3.1                 | 2.3.1.0        | delete commands not supported  | elastic2.3.1 |
+| 2.3.2                 | 2.3.2.0        | delete commands not supported  | elastic2.3.1 |
 
 ### Elasticsearch 1.X
 ````
@@ -75,6 +77,10 @@ Versions
 ### Elasticsearch 2.3.1
 ````
 ./bin/plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/2.3.1.0/elasticsearch-sql-2.3.1.0.zip 
+````
+### Elasticsearch 2.3.2
+````
+./bin/plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/2.3.2.0/elasticsearch-sql-2.3.2.0.zip 
 ````
 
 After doing this, you need to restart the Elasticsearch server. Otherwise you may get errors like `Invalid index name [sql], must not start with '']; ","status":400}`.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Versions
 | 2.3.0                 | 2.3.0.0        | delete commands not supported  | elastic2.3.0 |
 | 2.3.1                 | 2.3.1.0        | delete commands not supported  | elastic2.3.1 |
 | 2.3.2                 | 2.3.2.0        | delete commands not supported  | elastic2.3.2 |
-| 2.3.3                 | 2.3.2.0        | delete commands not supported  | elastic2.3.3 |
+| 2.3.3                 | 2.3.3.0        | delete commands not supported  | elastic2.3.3 |
 
 ### Elasticsearch 1.X
 ````

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Versions
 | 2.2.0                 | 2.2.0.1        | delete commands not supported  | elastic2.2.0 |
 | 2.2.1                 | 2.2.1.0        | delete commands not supported  | elastic2.2.1 |
 | 2.3.0                 | 2.3.0.0        | delete commands not supported  | elastic2.3.0 |
-| 2.3.1                 | 2.3.1.0        | delete commands not supported  | elastic2.3.1 |
+| 2.3.1                 | 2.3.1.1        | delete commands not supported  | elastic2.3.1 |
 | 2.3.2                 | 2.3.2.0        | delete commands not supported  | elastic2.3.2 |
 | 2.3.3                 | 2.3.3.0        | delete commands not supported  | elastic2.3.3 |
 | 2.3.4                 | 2.3.4.0        | delete commands not supported  | elastic2.3.4 |
@@ -83,7 +83,7 @@ Versions
 ````
 ### Elasticsearch 2.3.1
 ````
-./bin/plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/2.3.1.0/elasticsearch-sql-2.3.1.0.zip 
+./bin/plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/2.3.1.1/elasticsearch-sql-2.3.1.1.zip 
 ````
 ### Elasticsearch 2.3.2
 ````

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 Elasticsearch-SQL
 =================
-**1.X** [![1.X Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=master)](https://travis-ci.org/NLPchina/elasticsearch-sql) <br>
-**2.0.0** [![2.0.0 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.0)](https://travis-ci.org/NLPchina/elasticsearch-sql)<br>
-**2.1.0** [![2.1.0 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.1)](https://travis-ci.org/NLPchina/elasticsearch-sql)<br>
-**2.1.1** [![2.1.1 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.1.1)](https://travis-ci.org/NLPchina/elasticsearch-sql)<br>
+###build status
+**1.X** [![1.X Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=master)](https://travis-ci.org/NLPchina/elasticsearch-sql)
+**2.0.0** [![2.0.0 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.0)](https://travis-ci.org/NLPchina/elasticsearch-sql)
+**2.1.0** [![2.1.0 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.1)](https://travis-ci.org/NLPchina/elasticsearch-sql)
+**2.1.1** [![2.1.1 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.1.1)](https://travis-ci.org/NLPchina/elasticsearch-sql)
+**2.1.2** [![2.1.2 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.1.2)](https://travis-ci.org/NLPchina/elasticsearch-sql)
+**2.2.0** [![2.2.0 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.2.0)](https://travis-ci.org/NLPchina/elasticsearch-sql)
+**2.2.1** [![2.2.1 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.2.1)](https://travis-ci.org/NLPchina/elasticsearch-sql)
 
 Query elasticsearch using familiar SQL syntax.
 You can also use ES functions in SQL.
@@ -24,31 +28,37 @@ Versions
 
 | elasticsearch version | latest version | remarks                        | branch       |
 | --------------------- | -------------  | -----------------------------  | ------------ |
-| 1.X	                | 1.4.8          | tested against elastic 1.4-1.6 | master       |
-| 2.0.0                 | 2.0.3          | delete commands not supported  | elastic2.0   |
-| 2.1.0                 | 2.1.0.1        | delete commands not supported  | elastic2.1   |
-| 2.1.1                 | 2.1.1          | delete commands not supported  | elastic2.1.1 |
-| 2.2.0                 | 2.2.0          | delete commands not supported  | elastic2.2.0 |
+| 1.X	                | 1.4.9          | tested against elastic 1.4-1.6 | master       |
+| 2.0.0                 | 2.0.4          | delete commands not supported  | elastic2.0   |
+| 2.1.0                 | 2.1.0.2        | delete commands not supported  | elastic2.1   |
+| 2.1.1                 | 2.1.1.1        | delete commands not supported  | elastic2.1.1 |
+| 2.1.2                 | 2.1.2.0        | delete commands not supported  | elastic2.1.2 |
+| 2.2.0                 | 2.2.0.1        | delete commands not supported  | elastic2.2.0 |
+| 2.2.1                 | 2.2.1.0        | delete commands not supported  | elastic2.2.1 |
 
 ### Elasticsearch 1.X
 ````
-./bin/plugin -u https://github.com/NLPchina/elasticsearch-sql/releases/download/1.4.8/elasticsearch-sql-1.4.8.zip --install sql
+./bin/plugin -u https://github.com/NLPchina/elasticsearch-sql/releases/download/1.4.9/elasticsearch-sql-1.4.9.zip --install sql
 ````
 ### Elasticsearch 2.0.0
 ````
-./bin/plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/2.0.3/elasticsearch-sql-2.0.3.zip 
+./bin/plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/2.0.4/elasticsearch-sql-2.0.4.zip 
 ````
 ### Elasticsearch 2.1.0
 ````
-./bin/plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/2.1.0.1/elasticsearch-sql-2.1.0.1.zip 
+./bin/plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/2.1.0.2/elasticsearch-sql-2.1.0.2.zip 
 ````
 ### Elasticsearch 2.1.1
 ````
-./bin/plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/2.1.1/elasticsearch-sql-2.1.1.zip 
+./bin/plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/2.1.1.1/elasticsearch-sql-2.1.1.1.zip 
 ````
 ### Elasticsearch 2.2.0
 ````
-./bin/plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/2.2.0/elasticsearch-sql-2.2.0.zip 
+./bin/plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/2.2.0.1/elasticsearch-sql-2.2.0.1.zip 
+````
+### Elasticsearch 2.2.1
+````
+./bin/plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/2.2.1.0/elasticsearch-sql-2.2.1.0.zip 
 ````
 After doing this, you need to restart the Elasticsearch server. Otherwise you may get errors like `Invalid index name [sql], must not start with '']; ","status":400}`.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Elasticsearch-SQL
 **2.3.1** [![2.3.1 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.3.1)](https://travis-ci.org/NLPchina/elasticsearch-sql)
 **2.3.2** [![2.3.2 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.3.2)](https://travis-ci.org/NLPchina/elasticsearch-sql)
 **2.3.3** [![2.3.3 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.3.3)](https://travis-ci.org/NLPchina/elasticsearch-sql)
+**2.3.4** [![2.3.4 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.3.4)](https://travis-ci.org/NLPchina/elasticsearch-sql)
 
 Query elasticsearch using familiar SQL syntax.
 You can also use ES functions in SQL.
@@ -43,6 +44,7 @@ Versions
 | 2.3.1                 | 2.3.1.0        | delete commands not supported  | elastic2.3.1 |
 | 2.3.2                 | 2.3.2.0        | delete commands not supported  | elastic2.3.2 |
 | 2.3.3                 | 2.3.3.0        | delete commands not supported  | elastic2.3.3 |
+| 2.3.4                 | 2.3.4.0        | delete commands not supported  | elastic2.3.4 |
 
 ### Elasticsearch 1.X
 ````
@@ -87,6 +89,10 @@ Versions
 ### Elasticsearch 2.3.3
 ````
 ./bin/plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/2.3.3.0/elasticsearch-sql-2.3.3.0.zip 
+````
+### Elasticsearch 2.3.4
+````
+./bin/plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/2.3.4.0/elasticsearch-sql-2.3.4.0.zip 
 ````
 
 After doing this, you need to restart the Elasticsearch server. Otherwise you may get errors like `Invalid index name [sql], must not start with '']; ","status":400}`.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Elasticsearch-SQL
 **2.3.0** [![2.3.0 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.3.0)](https://travis-ci.org/NLPchina/elasticsearch-sql)
 **2.3.1** [![2.3.1 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.3.1)](https://travis-ci.org/NLPchina/elasticsearch-sql)
 **2.3.2** [![2.3.2 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.3.2)](https://travis-ci.org/NLPchina/elasticsearch-sql)
+**2.3.3** [![2.3.3 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.3.3)](https://travis-ci.org/NLPchina/elasticsearch-sql)
 
 Query elasticsearch using familiar SQL syntax.
 You can also use ES functions in SQL.
@@ -40,7 +41,8 @@ Versions
 | 2.2.1                 | 2.2.1.0        | delete commands not supported  | elastic2.2.1 |
 | 2.3.0                 | 2.3.0.0        | delete commands not supported  | elastic2.3.0 |
 | 2.3.1                 | 2.3.1.0        | delete commands not supported  | elastic2.3.1 |
-| 2.3.2                 | 2.3.2.0        | delete commands not supported  | elastic2.3.1 |
+| 2.3.2                 | 2.3.2.0        | delete commands not supported  | elastic2.3.2 |
+| 2.3.3                 | 2.3.2.0        | delete commands not supported  | elastic2.3.3 |
 
 ### Elasticsearch 1.X
 ````
@@ -81,6 +83,10 @@ Versions
 ### Elasticsearch 2.3.2
 ````
 ./bin/plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/2.3.2.0/elasticsearch-sql-2.3.2.0.zip 
+````
+### Elasticsearch 2.3.3
+````
+./bin/plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/2.3.3.0/elasticsearch-sql-2.3.3.0.zip 
 ````
 
 After doing this, you need to restart the Elasticsearch server. Otherwise you may get errors like `Invalid index name [sql], must not start with '']; ","status":400}`.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ You can also use ES functions in SQL.
 
 **Check out our [wiki!](https://github.com/NLPchina/elasticsearch-sql/wiki)**
 
+## explain example 
+
+you can visite : [http://www.nlpcn.org:9999/web/](http://www.nlpcn.org:9999/web/) , it is a sample example for explain
 
 ## Web frontend overview
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.nlpcn</groupId>
     <artifactId>elasticsearch-sql</artifactId>
-    <version>1.4.8</version>
+    <version>1.4.9</version>
     <packaging>jar</packaging>
     <description>Query elasticsearch using SQL</description>
     <name>elasticsearch-sql</name>

--- a/src/main/java/org/nlpcn/es4sql/domain/hints/HintFactory.java
+++ b/src/main/java/org/nlpcn/es4sql/domain/hints/HintFactory.java
@@ -58,8 +58,11 @@ public class HintFactory {
         if(hintAsString.startsWith("! DOCS_WITH_AGGREGATION")) {
             String[] number = getParamsFromHint(hintAsString,"! DOCS_WITH_AGGREGATION");
             //todo: check if numbers etc..
-            int docsWithAggregation = Integer.parseInt(number[0]);
-            return new Hint(HintType.DOCS_WITH_AGGREGATION,new Object[]{docsWithAggregation});
+            Integer[] params = new Integer[number.length];
+            for (int i = 0; i < params.length; i++) {
+                params[i] = Integer.parseInt(number[i]);
+            }
+            return new Hint(HintType.DOCS_WITH_AGGREGATION, params);
         }
         if(hintAsString.startsWith("! ROUTINGS")) {
             String[] routings = getParamsFromHint(hintAsString,"! ROUTINGS");

--- a/src/main/java/org/nlpcn/es4sql/query/AggregationQueryAction.java
+++ b/src/main/java/org/nlpcn/es4sql/query/AggregationQueryAction.java
@@ -56,7 +56,7 @@ public class AggregationQueryAction extends QueryAction {
 				Field field = groupBy.get(0);
 				lastAgg = aggMaker.makeGroupAgg(field);
 
-				if (lastAgg != null && lastAgg instanceof TermsBuilder) {
+				if (lastAgg != null && lastAgg instanceof TermsBuilder && !(field instanceof MethodField )) {
 					((TermsBuilder) lastAgg).size(select.getRowCount());
 				}
 

--- a/src/main/java/org/nlpcn/es4sql/query/maker/AggMaker.java
+++ b/src/main/java/org/nlpcn/es4sql/query/maker/AggMaker.java
@@ -1,5 +1,6 @@
 package org.nlpcn.es4sql.query.maker;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -22,6 +23,7 @@ import org.elasticsearch.search.aggregations.bucket.terms.TermsBuilder;
 import org.elasticsearch.search.aggregations.metrics.MetricsAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.ValuesSourceMetricsAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.geobounds.GeoBoundsBuilder;
+import org.elasticsearch.search.aggregations.metrics.percentiles.PercentilesBuilder;
 import org.elasticsearch.search.aggregations.metrics.scripted.ScriptedMetricBuilder;
 import org.elasticsearch.search.aggregations.metrics.tophits.TopHitsBuilder;
 import org.elasticsearch.search.sort.SortOrder;
@@ -96,6 +98,7 @@ public class AggMaker {
             return addFieldOrScriptToAggregation(field, builder);
         case "PERCENTILES":
             builder = AggregationBuilders.percentiles(field.getAlias());
+            addSpecificPercentiles((PercentilesBuilder) builder,field.getParams());
             return addFieldOrScriptToAggregation(field, builder);
 		case "TOPHITS":
 			return makeTopHitsAgg(field);
@@ -108,6 +111,26 @@ public class AggMaker {
 			throw new SqlParseException("the agg function not to define !");
 		}
 	}
+
+    private void addSpecificPercentiles(PercentilesBuilder percentilesBuilder, List<KVValue> params) {
+        List<Double> percentiles = new ArrayList<>();
+        for(KVValue kValue : params ){
+            if(kValue.value.getClass().equals(BigDecimal.class)){
+                BigDecimal percentile = (BigDecimal) kValue.value;
+                percentiles.add(percentile.doubleValue());
+
+            }
+        }
+        if(percentiles.size() > 0) {
+            double[] percentilesArr = new double[percentiles.size()];
+            int i=0;
+            for (Double percentile : percentiles){
+                percentilesArr[i] = percentile;
+                i++;
+            }
+            percentilesBuilder.percentiles(percentilesArr);
+        }
+    }
 
     private String fixAlias(String alias) {
         //because [ is not legal as alias

--- a/src/main/java/org/nlpcn/es4sql/query/maker/AggMaker.java
+++ b/src/main/java/org/nlpcn/es4sql/query/maker/AggMaker.java
@@ -234,6 +234,9 @@ public class AggMaker {
                 case "shard_size":
                     terms.shardSize(Integer.parseInt(value));
                     break;
+                case "min_doc_count":
+                    terms.minDocCount(Integer.parseInt(value));
+                    break;
                 case "alias":
                 case "nested":
                 case "reverse_nested":

--- a/src/main/java/org/nlpcn/es4sql/query/maker/Maker.java
+++ b/src/main/java/org/nlpcn/es4sql/query/maker/Maker.java
@@ -156,9 +156,9 @@ public abstract class Maker {
 			}
 		case LIKE:
         case NLIKE:
-			String queryStr = ((String) value).replace("[%]","ESCAPEDPERCENTAGE").replace("[_]","ESCAPEDUNDERSCORE");
+			String queryStr = ((String) value);
             queryStr = queryStr.replace('%', '*').replace('_', '?');
-            queryStr = queryStr.replace("ESCAPEDPERCENTAGE","%").replace("ESCAPEDUNDERSCORE","_");
+            queryStr = queryStr.replace("&PERCENT","%").replace("&UNDERSCORE","_");
 			WildcardQueryBuilder wildcardQuery = QueryBuilders.wildcardQuery(name, queryStr);
 			x = isQuery ? wildcardQuery : FilterBuilders.queryFilter(wildcardQuery);
 			break;

--- a/src/test/java/org/nlpcn/es4sql/AggregationTest.java
+++ b/src/test/java/org/nlpcn/es4sql/AggregationTest.java
@@ -254,6 +254,15 @@ public class AggregationTest {
 
     }
 
+    @Test
+    public void termsWithSize() throws Exception {
+        Map<String, Set<Integer>> buckets = new HashMap<>();
+
+        Aggregations result = query(String.format("SELECT COUNT(*) FROM %s/account GROUP BY terms('alias'='ageAgg','field'='age','size'=3)", TEST_INDEX));
+        Terms gender = result.get("ageAgg");
+        Assert.assertEquals(3,gender.getBuckets().size());
+
+    }
 
 
     @Test

--- a/src/test/java/org/nlpcn/es4sql/AggregationTest.java
+++ b/src/test/java/org/nlpcn/es4sql/AggregationTest.java
@@ -374,6 +374,30 @@ public class AggregationTest {
 
 
     @Test
+    public void testFromSizeWithAggregations() throws Exception {
+        final String query1 = String.format("SELECT /*! DOCS_WITH_AGGREGATION(0,1) */" +
+                " account_number FROM %s/account GROUP BY gender", TEST_INDEX);
+        SearchResponse response1 = (SearchResponse) getSearchRequestBuilder(query1).get();
+
+        Assert.assertEquals(1, response1.getHits().getHits().length);
+        Terms gender1 = response1.getAggregations().get("gender");
+        Assert.assertEquals(2, gender1.getBuckets().size());
+        Object account1 = response1.getHits().getHits()[0].getSource().get("account_number");
+
+        final String query2 = String.format("SELECT /*! DOCS_WITH_AGGREGATION(1,1) */" +
+                " account_number FROM %s/account GROUP BY gender", TEST_INDEX);
+        SearchResponse response2 = (SearchResponse) getSearchRequestBuilder(query2).get();
+
+        Assert.assertEquals(1, response2.getHits().getHits().length);
+        Terms gender2 = response2.getAggregations().get("gender");
+        Assert.assertEquals(2, gender2.getBuckets().size());
+        Object account2 = response2.getHits().getHits()[0].getSource().get("account_number");
+
+        Assert.assertEquals(response1.getHits().getTotalHits(), response2.getHits().getTotalHits());
+        Assert.assertNotEquals(account1, account2);
+    }
+
+    @Test
 	public void testSubAggregations() throws  Exception {
 		Set expectedAges = new HashSet<>(ContiguousSet.create(Range.closed(20, 40), DiscreteDomain.integers()));
 		final String query = String.format("SELECT /*! DOCS_WITH_AGGREGATION(10) */" +

--- a/src/test/java/org/nlpcn/es4sql/AggregationTest.java
+++ b/src/test/java/org/nlpcn/es4sql/AggregationTest.java
@@ -179,6 +179,14 @@ public class AggregationTest {
     }
 
     @Test
+    public void percentileTestSpecific() throws IOException, SqlParseException, SQLFeatureNotSupportedException {
+        Aggregations result = query(String.format("SELECT PERCENTILES(age,25.0,75.0) x FROM %s/account", TEST_INDEX));
+        Percentiles percentiles = result.get("x");
+        Assert.assertTrue(Math.abs(percentiles.percentile(25.0) - 25.0) < 0.001 );
+        Assert.assertTrue(Math.abs(percentiles.percentile(75.0) - 35.0) < 0.001 );
+    }
+
+    @Test
 	public void aliasTest() throws IOException, SqlParseException, SQLFeatureNotSupportedException {
 		Aggregations result = query(String.format("SELECT COUNT(*) AS mycount FROM %s/account", TEST_INDEX));
 		assertThat(result.asMap(), hasKey("mycount"));

--- a/src/test/java/org/nlpcn/es4sql/SqlParserTests.java
+++ b/src/test/java/org/nlpcn/es4sql/SqlParserTests.java
@@ -782,7 +782,7 @@ public class SqlParserTests {
 
     @Test
     public void likeTestWithEscaped() throws SqlParseException {
-        String query = "select * from x where name like '[_]hey_%[%]'";
+        String query = "select * from x where name like '&UNDERSCOREhey_%&PERCENT'";
         Select select = parser.parseSelect((SQLQueryExpr) queryToExpr(query));
         BoolFilterBuilder explan = FilterMaker.explan(select.getWhere());
         String filterAsString = explan.toString();


### PR DESCRIPTION
CSV export via REST API leads in version 2.3.1 to NPE, if there are null values in the ES documents in following line (300) of CSVResultsExtractor:

if (doc.containsKey(header)) {
                return doc.get(header).toString() + separator;
[CSVResultsExtractor.zip](https://github.com/NLPchina/elasticsearch-sql/files/383279/CSVResultsExtractor.zip)

            }

I have changed this to:

if (doc.containsKey(header)) {
                return String.valueOf(doc.get(header)) + separator;
            }



