### PR TITLE
fix issuse https://github.com/NLPchina/elasticsearch-sql/issues/265#i…

### DIFF
--- a/src/main/java/org/nlpcn/es4sql/Test.java
+++ b/src/main/java/org/nlpcn/es4sql/Test.java
@@ -75,10 +75,7 @@ public class Test {
                 "group by key ";
         String TEST_INDEX = "elasticsearch-sql_test_index";
 
-        sql =  "SELECT " +
-                " concat_ws('-',age,'-') from " +
-                TEST_INDEX + "/account " +
-                " limit 10  ";
+        sql =  "select count(t.*) as counts,sum(t.size) from xxx/locs as t group by t.kk";
 
         System.out.println("sql" + sql + ":\n----------\n" + sqlToEsQuery(sql));
 

--- a/src/main/java/org/nlpcn/es4sql/Util.java
+++ b/src/main/java/org/nlpcn/es4sql/Util.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.alibaba.druid.sql.ast.expr.*;
+import org.nlpcn.es4sql.domain.Field;
 import org.nlpcn.es4sql.domain.KVValue;
 import org.nlpcn.es4sql.exception.SqlParseException;
 
@@ -11,91 +12,107 @@ import com.alibaba.druid.sql.ast.*;
 
 
 public class Util {
-	public static String joiner(List<KVValue> lists, String oper) {
-		
-		if (lists.size() == 0) {
-			return null;
-		}
+    public static String joiner(List<KVValue> lists, String oper) {
 
-		StringBuilder sb = new StringBuilder(lists.get(0).toString());
-		for (int i = 1; i < lists.size(); i++) {
-			sb.append(oper);
-			sb.append(lists.get(i).toString());
-		}
+        if (lists.size() == 0) {
+            return null;
+        }
 
-		return sb.toString();
-	}
+        StringBuilder sb = new StringBuilder(lists.get(0).toString());
+        for (int i = 1; i < lists.size(); i++) {
+            sb.append(oper);
+            sb.append(lists.get(i).toString());
+        }
 
-	public static List<Map<String, Object>> sortByMap(List<Map<String, Object>> lists) {
+        return sb.toString();
+    }
 
-		return lists;
-	}
+    public static List<Map<String, Object>> sortByMap(List<Map<String, Object>> lists) {
 
-	public static Object expr2Object(SQLExpr expr) {
-		Object value = null;
-		if (expr instanceof SQLNumericLiteralExpr) {
-			value = ((SQLNumericLiteralExpr) expr).getNumber();
-		} else if (expr instanceof SQLCharExpr) {
-			value = ((SQLCharExpr) expr).getText();
-		} else if (expr instanceof SQLIdentifierExpr) {
-			value = expr.toString();
-		} else if (expr instanceof SQLPropertyExpr) {
+        return lists;
+    }
+
+    public static Object removeTableAilasFromField(Object expr, String tableAlias) {
+
+        if (expr instanceof SQLIdentifierExpr || expr instanceof SQLPropertyExpr || expr instanceof SQLVariantRefExpr) {
+            String name = expr.toString().replace("`", "");
+            if (tableAlias != null) {
+                String aliasPrefix = tableAlias + ".";
+                if (name.startsWith(aliasPrefix)) {
+                    String newFieldName = name.replaceFirst(aliasPrefix, "");
+                    return new SQLIdentifierExpr(newFieldName);
+                }
+            }
+        }
+        return expr;
+    }
+
+
+    public static Object expr2Object(SQLExpr expr) {
+        Object value = null;
+        if (expr instanceof SQLNumericLiteralExpr) {
+            value = ((SQLNumericLiteralExpr) expr).getNumber();
+        } else if (expr instanceof SQLCharExpr) {
+            value = ((SQLCharExpr) expr).getText();
+        } else if (expr instanceof SQLIdentifierExpr) {
             value = expr.toString();
-        }else if (expr instanceof SQLVariantRefExpr ){
+        } else if (expr instanceof SQLPropertyExpr) {
             value = expr.toString();
-		}else if (expr instanceof SQLAllColumnExpr) {
-			value = "*";
-		} else if (expr instanceof  SQLValuableExpr){
-            value = ((SQLValuableExpr)expr).getValue();
+        } else if (expr instanceof SQLVariantRefExpr) {
+            value = expr.toString();
+        } else if (expr instanceof SQLAllColumnExpr) {
+            value = "*";
+        } else if (expr instanceof SQLValuableExpr) {
+            value = ((SQLValuableExpr) expr).getValue();
         } else {
-			//throw new SqlParseException("can not support this type " + expr.getClass());
-		}
-		return value;
-	}
+            //throw new SqlParseException("can not support this type " + expr.getClass());
+        }
+        return value;
+    }
 
-	public static Object getScriptValue(SQLExpr expr) throws SqlParseException {
-		if (expr instanceof SQLIdentifierExpr || expr instanceof SQLPropertyExpr || expr instanceof SQLVariantRefExpr) {
-			return "doc['" + expr.toString() + "'].value";
-		} else if (expr instanceof SQLValuableExpr) {
-			return ((SQLValuableExpr) expr).getValue();
-		}
-		throw new SqlParseException("could not parse sqlBinaryOpExpr need to be identifier/valuable got" + expr.getClass().toString() + " with value:" + expr.toString());
-	}
+    public static Object getScriptValue(SQLExpr expr) throws SqlParseException {
+        if (expr instanceof SQLIdentifierExpr || expr instanceof SQLPropertyExpr || expr instanceof SQLVariantRefExpr) {
+            return "doc['" + expr.toString() + "'].value";
+        } else if (expr instanceof SQLValuableExpr) {
+            return ((SQLValuableExpr) expr).getValue();
+        }
+        throw new SqlParseException("could not parse sqlBinaryOpExpr need to be identifier/valuable got" + expr.getClass().toString() + " with value:" + expr.toString());
+    }
 
-	public static double[] String2DoubleArr(String paramer) {
-		String[] split = paramer.split(",");
-		double[] ds = new double[split.length];
-		for (int i = 0; i < ds.length; i++) {
-			ds[i] = Double.parseDouble(split[i].trim());
-		}
-		return ds;
-	}
+    public static double[] String2DoubleArr(String paramer) {
+        String[] split = paramer.split(",");
+        double[] ds = new double[split.length];
+        for (int i = 0; i < ds.length; i++) {
+            ds[i] = Double.parseDouble(split[i].trim());
+        }
+        return ds;
+    }
 
-	public static double[] KV2DoubleArr(List<KVValue> params) {
-		double[] ds = new double[params.size()];
-		int i = 0;
-		for (KVValue v : params) {
-			ds[i] = ((Number) v.value).doubleValue();
-			i++;
-		}
-		return ds;
-	}
+    public static double[] KV2DoubleArr(List<KVValue> params) {
+        double[] ds = new double[params.size()];
+        int i = 0;
+        for (KVValue v : params) {
+            ds[i] = ((Number) v.value).doubleValue();
+            i++;
+        }
+        return ds;
+    }
 
 
     public static String extendedToString(SQLExpr sqlExpr) {
-        if(sqlExpr instanceof SQLTextLiteralExpr){
+        if (sqlExpr instanceof SQLTextLiteralExpr) {
             return ((SQLTextLiteralExpr) sqlExpr).getText();
         }
         return sqlExpr.toString();
     }
 
-    public static String[] concatStringsArrays(String[] a1,String[] a2){
+    public static String[] concatStringsArrays(String[] a1, String[] a2) {
         String[] strings = new String[a1.length + a2.length];
-        for(int i=0;i<a1.length;i++){
+        for (int i = 0; i < a1.length; i++) {
             strings[i] = a1[i];
         }
-        for(int i = 0;i<a2.length;i++){
-            strings[a1.length+i] = a2[i];
+        for (int i = 0; i < a2.length; i++) {
+            strings[a1.length + i] = a2[i];
         }
         return strings;
     }

--- a/src/test/java/org/nlpcn/es4sql/SQLFunctionsTest.java
+++ b/src/test/java/org/nlpcn/es4sql/SQLFunctionsTest.java
@@ -101,7 +101,7 @@ public class SQLFunctionsTest {
         List<String> headers = csvResult.getHeaders();
         List<String> contents = csvResult.getLines();
         String[] splits = contents.get(0).split(",");
-        Assert.assertTrue(splits[1].endsWith("--"));
+        Assert.assertTrue(splits[0].endsWith("--"));
     }
 
     @Test

--- a/src/test/java/org/nlpcn/es4sql/SqlParserTests.java
+++ b/src/test/java/org/nlpcn/es4sql/SqlParserTests.java
@@ -538,6 +538,22 @@ public class SqlParserTests {
         Assert.assertEquals("message.moreNested", condition.getNestedPath());
         Assert.assertEquals("message.moreNested.name", condition.getName());
     }
+    
+
+    @Test
+    public void aggFieldWithAliasTableAliasShouldBeRemoved() throws SqlParseException {
+        String query = "select count(t.*) as counts,sum(t.size) from xxx/locs as t group by t.kk";
+        SQLExpr sqlExpr = queryToExpr(query);
+        Select select = parser.parseSelect((SQLQueryExpr) sqlExpr);
+        List<Field> fields = select.getFields();
+        Assert.assertTrue(fields.size()==2);
+        Assert.assertEquals("COUNT(*)",fields.get(0).toString());
+        Assert.assertEquals("SUM(size)",fields.get(1).toString());
+        List<List<Field>> groups = select.getGroupBys();
+        Assert.assertTrue(groups.size()==1);
+        Assert.assertTrue(groups.get(0).size()==1);
+        Assert.assertEquals("kk",groups.get(0).get(0).getName());
+    }
 
     @Test
     public void nestedFieldOnWhereGivenPath() throws SqlParseException {


### PR DESCRIPTION

## Fix Issue :

```
https://github.com/NLPchina/elasticsearch-sql/issues/265#issuecomment-242388650
```

## Unit test

```
org.nlpcn.es4sql.SqlParserTests.aggFieldWithAliasTableAliasShouldBeRemoved
```

## Example

```
select count(t.*) as counts,sum(t.size) from xxx/locs as t group by t.kk
```

will be translate to 

```
{
  "from" : 0,
  "size" : 0,
  "_source" : {
    "includes" : [ "COUNT", "SUM" ],
    "excludes" : [ ]
  },
  "aggregations" : {
    "kk" : {
      "terms" : {
        "field" : "kk",
        "size" : 200
      },
      "aggregations" : {
        "counts" : {
          "value_count" : {
            "field" : "_index"
          }
        },
        "SUM(size)" : {
          "sum" : {
            "field" : "size"
          }
        }
      }
    }
  }
}
```