### PR TITLE
fix issue: https://github.com/NLPchina/elasticsearch-sql/issues/277

### DIFF
--- a/src/main/java/org/nlpcn/es4sql/SQLFunctions.java
+++ b/src/main/java/org/nlpcn/es4sql/SQLFunctions.java
@@ -23,7 +23,7 @@ public class SQLFunctions {
             "random", "abs", //nummber operator
             "split", "concat_ws", "substring", "trim",//string operator
             "add", "multiply", "divide", "subtract", "modulus",//binary operator
-            "field"
+            "field", "date_format"
     );
 
 
@@ -54,6 +54,13 @@ public class SQLFunctions {
 
             case "floor":
                 functionStr = floor(Util.expr2Object((SQLExpr) paramers.get(0).value).toString(), name);
+                break;
+
+            case "date_format":
+                functionStr = date_format(
+                        Util.expr2Object((SQLExpr) paramers.get(0).value).toString(),
+                        Util.expr2Object((SQLExpr) paramers.get(1).value).toString(),
+                        name);
                 break;
 
             case "round":
@@ -115,7 +122,6 @@ public class SQLFunctions {
 
     public static Tuple<String, String> concat_ws(String split, List<SQLExpr> columns, String valueName) {
         String name = "concat_ws_" + random();
-
         List<String> result = Lists.newArrayList();
 
         for (SQLExpr column : columns) {
@@ -125,7 +131,7 @@ public class SQLFunctions {
             } else if (isProperty(column)) {
                 result.add("doc['" + strColumn + "'].value");
             } else {
-                result.add("'"+strColumn+"'");
+                result.add("'" + strColumn + "'");
             }
 
         }
@@ -141,6 +147,16 @@ public class SQLFunctions {
             return new Tuple(name, "def " + name + " = doc['" + strColumn + "'].value.split('" + pattern + "')[" + index + "]");
         } else {
             return new Tuple(name, strColumn + "; def " + name + " = " + valueName + ".split('" + pattern + "')[" + index + "]");
+        }
+
+    }
+
+    public static Tuple<String, String> date_format(String strColumn, String pattern, String valueName) {
+        String name = "date_format_" + random();
+        if (valueName == null) {
+            return new Tuple(name, "def " + name + " = new Date(doc['" + strColumn + "'].value - 8*1000*60*60).format('" + pattern + "') ");
+        } else {
+            return new Tuple(name, strColumn + "; def " + name + " = new Date(" + valueName + " - 8*1000*60*60).format('" + pattern + "')");
         }
 
     }

--- a/src/main/java/org/nlpcn/es4sql/Util.java
+++ b/src/main/java/org/nlpcn/es4sql/Util.java
@@ -2,8 +2,11 @@ package org.nlpcn.es4sql;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.alibaba.druid.sql.ast.expr.*;
+import com.alibaba.druid.sql.ast.statement.SQLJoinTableSource;
+import com.alibaba.druid.sql.ast.statement.SQLSelectQueryBlock;
 import org.nlpcn.es4sql.domain.Field;
 import org.nlpcn.es4sql.domain.KVValue;
 import org.nlpcn.es4sql.exception.SqlParseException;
@@ -81,6 +84,26 @@ public class Util {
             return ((SQLValuableExpr) expr).getValue();
         }
         throw new SqlParseException("could not parse sqlBinaryOpExpr need to be identifier/valuable got" + expr.getClass().toString() + " with value:" + expr.toString());
+    }
+
+    public static boolean isFromJoinTable(SQLExpr expr) {
+        SQLObject temp = expr;
+        AtomicInteger counter = new AtomicInteger(10);
+        while (temp != null &&
+                !(expr instanceof SQLSelectQueryBlock) &&
+                !(expr instanceof SQLJoinTableSource) && counter.get() > 0) {
+            counter.decrementAndGet();
+            temp = temp.getParent();
+            if (temp instanceof SQLSelectQueryBlock) {
+                if (((SQLSelectQueryBlock) temp).getFrom() instanceof SQLJoinTableSource) {
+                    return true;
+                }
+            }
+            if (temp instanceof SQLJoinTableSource) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static double[] String2DoubleArr(String paramer) {

--- a/src/main/java/org/nlpcn/es4sql/parse/FieldMaker.java
+++ b/src/main/java/org/nlpcn/es4sql/parse/FieldMaker.java
@@ -170,20 +170,7 @@ public class FieldMaker {
         return methodInvokeExpr;
     }
 
-    private static boolean isFromJoinTable(SQLExpr expr) {
-        SQLObject temp = expr;
-        AtomicInteger counter = new AtomicInteger(10);
-        while (temp != null && !(expr.getParent() instanceof SQLSelectQueryBlock) && counter.get() > 0) {
-            counter.decrementAndGet();
-            temp = temp.getParent();
-            if (temp instanceof SQLSelectQueryBlock) {
-                if (((SQLSelectQueryBlock) temp).getFrom() instanceof SQLJoinTableSource) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
+
 
     private static Field handleIdentifier(SQLExpr expr, String alias, String tableAlias) throws SqlParseException {
         String name = expr.toString().replace("`", "");
@@ -201,7 +188,7 @@ public class FieldMaker {
             field = new Field(newFieldName, alias);
         }
 
-        if (alias != null && alias != name && !isFromJoinTable(expr)) {
+        if (alias != null && alias != name && !Util.isFromJoinTable(expr)) {
             List<SQLExpr> paramers = Lists.newArrayList();
             paramers.add(new SQLCharExpr(alias));
             paramers.add(new SQLCharExpr("doc['" + newFieldName + "'].value"));

--- a/src/test/java/org/nlpcn/es4sql/SQLFunctionsTest.java
+++ b/src/test/java/org/nlpcn/es4sql/SQLFunctionsTest.java
@@ -21,6 +21,8 @@ import java.net.UnknownHostException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.List;
 
+import static org.nlpcn.es4sql.TestsConstants.TEST_INDEX;
+
 /**
  * Created by allwefantasy on 8/25/16.
  */
@@ -104,6 +106,15 @@ public class SQLFunctionsTest {
         String[] splits = contents.get(0).split(",");
 		Assert.assertTrue(splits[0].endsWith("--")|| splits[1].endsWith("--"));
 	}
+
+    @Test
+    public void test() throws Exception {
+
+//        String query =  "select * from xxx/locs where floor(a) = floor(b)";
+//
+//        SearchDao searchDao = MainTestSuite.getSearchDao() != null ? MainTestSuite.getSearchDao() : getSearchDao();
+//        System.out.println(searchDao.explain(query).explain().explain());
+    }
 
 	@Test
     public void concat_ws_fields() throws Exception {

--- a/src/test/java/org/nlpcn/es4sql/SqlParserTests.java
+++ b/src/test/java/org/nlpcn/es4sql/SqlParserTests.java
@@ -834,6 +834,43 @@ public class SqlParserTests {
     }
 
     @Test
+    public void propertyEqualCondition() throws SqlParseException {
+        SQLExpr sqlExpr = queryToExpr("select * from xxx/locs where a = b");
+        Select select = parser.parseSelect((SQLQueryExpr) sqlExpr);
+        List<Where> wheres = select.getWhere().getWheres();
+        Assert.assertTrue(wheres.size()==1);
+        Condition condition = (Condition)wheres.get(0);
+        Assert.assertTrue(condition.getValue() instanceof  ScriptFilter);
+        ScriptFilter sf = (ScriptFilter)condition.getValue();
+        Assert.assertEquals(sf.getScript(),"doc['a'].value == doc['b'].value");
+    }
+
+
+    @Test
+    public void propertyWithTableAliasEqualCondition() throws SqlParseException {
+        SQLExpr sqlExpr = queryToExpr("select t.* from xxx/locs where t.a = t.b");
+        Select select = parser.parseSelect((SQLQueryExpr) sqlExpr);
+        List<Where> wheres = select.getWhere().getWheres();
+        Assert.assertTrue(wheres.size()==1);
+        Condition condition = (Condition)wheres.get(0);
+        Assert.assertTrue(condition.getValue() instanceof  ScriptFilter);
+        ScriptFilter sf = (ScriptFilter)condition.getValue();
+        Assert.assertEquals(sf.getScript(),"doc['a'].value == doc['b'].value");
+    }
+
+    @Test
+    public void propertyGreatCondition() throws SqlParseException {
+        SQLExpr sqlExpr = queryToExpr("select * from xxx/locs where a > b");
+        Select select = parser.parseSelect((SQLQueryExpr) sqlExpr);
+        List<Where> wheres = select.getWhere().getWheres();
+        Assert.assertTrue(wheres.size()==1);
+        Condition condition = (Condition)wheres.get(0);
+        Assert.assertTrue(condition.getValue() instanceof  ScriptFilter);
+        ScriptFilter sf = (ScriptFilter)condition.getValue();
+        Assert.assertEquals(sf.getScript(),"doc['a'].value > doc['b'].value");
+    }
+
+    @Test
     public void stringAndNumberEqualConditionWithoutProperty() throws SqlParseException {
         SQLExpr sqlExpr = queryToExpr("select * from xxx/locs where 'a' = 1");
         Select select = parser.parseSelect((SQLQueryExpr) sqlExpr);


### PR DESCRIPTION
## Example

```
select * from xxx/locs where a = b
select * from xxx/locs where a > b
select t.* from xxx/locs t where t.a > t.b
```

When the sql is join , this feature will not take effect. 

## Unit Test

```
org.nlpcn.es4sql.propertyEqualCondition
org.nlpcn.es4sql.propertyWithTableAliasEqualCondition
org.nlpcn.es4sql.propertyGreatCondition
```

