### PR TITLE
function support in where condition

### DIFF
--- a/src/main/java/org/nlpcn/es4sql/parse/ChildrenType.java
+++ b/src/main/java/org/nlpcn/es4sql/parse/ChildrenType.java
@@ -43,7 +43,7 @@ public class ChildrenType {
             this.simple = true;
         } else {
             Where where = Where.newInstance();
-            new SqlParser().parseWhere(secondParameter,where);
+            new WhereParser(new SqlParser()).parseWhere(secondParameter,where);
             if(where.getWheres().size() == 0)
                 throw new SqlParseException("unable to parse filter where.");
             this.where = where;

--- a/src/main/java/org/nlpcn/es4sql/parse/FieldMaker.java
+++ b/src/main/java/org/nlpcn/es4sql/parse/FieldMaker.java
@@ -56,10 +56,10 @@ public class FieldMaker {
                 return makeFilterMethodField(mExpr, alias);
             }
 
-            return makeMethodField(methodName, mExpr.getParameters(), null, alias, tableAlias,true);
+            return makeMethodField(methodName, mExpr.getParameters(), null, alias, tableAlias, true);
         } else if (expr instanceof SQLAggregateExpr) {
             SQLAggregateExpr sExpr = (SQLAggregateExpr) expr;
-            return makeMethodField(sExpr.getMethodName(), sExpr.getArguments(), sExpr.getOption(), alias,tableAlias, true);
+            return makeMethodField(sExpr.getMethodName(), sExpr.getArguments(), sExpr.getOption(), alias, tableAlias, true);
         } else {
             throw new SqlParseException("unknown field name : " + expr);
         }
@@ -70,7 +70,7 @@ public class FieldMaker {
         return Util.getScriptValue(expr);
     }
 
-    private static Field makeScriptMethodField(SQLBinaryOpExpr binaryExpr, String alias,String tableAlias) throws SqlParseException {
+    private static Field makeScriptMethodField(SQLBinaryOpExpr binaryExpr, String alias, String tableAlias) throws SqlParseException {
         List<SQLExpr> params = new ArrayList<>();
 
         String scriptFieldAlias;
@@ -86,7 +86,7 @@ public class FieldMaker {
 
         params.add(new SQLCharExpr(script));
 
-        return makeMethodField("script", params, null, null, tableAlias,false);
+        return makeMethodField("script", params, null, null, tableAlias, false);
     }
 
 
@@ -107,7 +107,7 @@ public class FieldMaker {
             exprToCheck = parameters.get(1);
         }
         Where where = Where.newInstance();
-        new SqlParser().parseWhere(exprToCheck, where);
+        new WhereParser(new SqlParser()).parseWhere(exprToCheck, where);
         if (where.getWheres().size() == 0)
             throw new SqlParseException("unable to parse filter where.");
         List<KVValue> methodParameters = new ArrayList<>();
@@ -133,7 +133,7 @@ public class FieldMaker {
 
 
     //binary method can nested
-    private static SQLMethodInvokeExpr makeBinaryMethodField(SQLBinaryOpExpr expr, String alias, boolean first) throws SqlParseException {
+    public static SQLMethodInvokeExpr makeBinaryMethodField(SQLBinaryOpExpr expr, String alias, boolean first) throws SqlParseException {
         List<SQLExpr> params = new ArrayList<>();
 
         String scriptFieldAlias;
@@ -171,7 +171,6 @@ public class FieldMaker {
     }
 
 
-
     private static Field handleIdentifier(SQLExpr expr, String alias, String tableAlias) throws SqlParseException {
         String name = expr.toString().replace("`", "");
         String newFieldName = name;
@@ -192,12 +191,12 @@ public class FieldMaker {
             List<SQLExpr> paramers = Lists.newArrayList();
             paramers.add(new SQLCharExpr(alias));
             paramers.add(new SQLCharExpr("doc['" + newFieldName + "'].value"));
-            field = makeMethodField("script", paramers, null, alias, tableAlias,true);
+            field = makeMethodField("script", paramers, null, alias, tableAlias, true);
         }
         return field;
     }
 
-    private static MethodField makeMethodField(String name, List<SQLExpr> arguments, SQLAggregateOption option, String alias,String tableAlias, boolean first) throws SqlParseException {
+    public static MethodField makeMethodField(String name, List<SQLExpr> arguments, SQLAggregateOption option, String alias, String tableAlias, boolean first) throws SqlParseException {
         List<KVValue> paramers = new LinkedList<>();
         String finalMethodName = name;
 
@@ -209,11 +208,11 @@ public class FieldMaker {
 
                 if (SQLFunctions.buildInFunctions.contains(binaryOpExpr.getOperator().toString().toLowerCase())) {
                     SQLMethodInvokeExpr mExpr = makeBinaryMethodField(binaryOpExpr, alias, first);
-                    MethodField abc = makeMethodField(mExpr.getMethodName(), mExpr.getParameters(), null, null,tableAlias, false);
+                    MethodField abc = makeMethodField(mExpr.getMethodName(), mExpr.getParameters(), null, null, tableAlias, false);
                     paramers.add(new KVValue(abc.getParams().get(0).toString(), new SQLCharExpr(abc.getParams().get(1).toString())));
                 } else {
                     if (!binaryOpExpr.getOperator().getName().equals("=")) {
-                        paramers.add(new KVValue("script", makeScriptMethodField(binaryOpExpr, null,tableAlias)));
+                        paramers.add(new KVValue("script", makeScriptMethodField(binaryOpExpr, null, tableAlias)));
                     } else {
                         SQLExpr right = binaryOpExpr.getRight();
                         Object value = Util.expr2Object(right);
@@ -225,7 +224,7 @@ public class FieldMaker {
                 SQLMethodInvokeExpr mExpr = (SQLMethodInvokeExpr) object;
                 String methodName = mExpr.getMethodName().toLowerCase();
                 if (methodName.equals("script")) {
-                    KVValue script = new KVValue("script", makeMethodField(mExpr.getMethodName(), mExpr.getParameters(), null, alias,tableAlias, true));
+                    KVValue script = new KVValue("script", makeMethodField(mExpr.getMethodName(), mExpr.getParameters(), null, alias, tableAlias, true));
                     paramers.add(script);
                 } else if (methodName.equals("nested") || methodName.equals("reverse_nested")) {
                     NestedType nestedType = new NestedType();
@@ -245,11 +244,11 @@ public class FieldMaker {
                     paramers.add(new KVValue("children", childrenType));
                 } else if (SQLFunctions.buildInFunctions.contains(methodName)) {
                     //throw new SqlParseException("only support script/nested as inner functions");
-                    MethodField abc = makeMethodField(methodName, mExpr.getParameters(), null, null, tableAlias,false);
+                    MethodField abc = makeMethodField(methodName, mExpr.getParameters(), null, null, tableAlias, false);
                     paramers.add(new KVValue(abc.getParams().get(0).toString(), new SQLCharExpr(abc.getParams().get(1).toString())));
                 } else throw new SqlParseException("only support script/nested/children as inner functions");
             } else {
-                paramers.add(new KVValue(Util.removeTableAilasFromField(object,tableAlias)));
+                paramers.add(new KVValue(Util.removeTableAilasFromField(object, tableAlias)));
             }
 
         }

--- a/src/main/java/org/nlpcn/es4sql/parse/NestedType.java
+++ b/src/main/java/org/nlpcn/es4sql/parse/NestedType.java
@@ -65,7 +65,7 @@ public class NestedType {
             else {
                 this.path = field;
                 Where where = Where.newInstance();
-                new SqlParser().parseWhere(secondParameter,where);
+                new WhereParser(new SqlParser()).parseWhere(secondParameter,where);
                 if(where.getWheres().size() == 0)
                     throw new SqlParseException("unable to parse filter where.");
                 this.where = where;

--- a/src/main/java/org/nlpcn/es4sql/parse/SelectParser.java
+++ b/src/main/java/org/nlpcn/es4sql/parse/SelectParser.java
@@ -1,0 +1,7 @@
+package org.nlpcn.es4sql.parse;
+
+/**
+ * Created by allwefantasy on 9/2/16.
+ */
+public class SelectParser {
+}

--- a/src/main/java/org/nlpcn/es4sql/parse/SqlParser.java
+++ b/src/main/java/org/nlpcn/es4sql/parse/SqlParser.java
@@ -9,14 +9,11 @@ import com.alibaba.druid.sql.dialect.mysql.ast.expr.MySqlSelectGroupByExpr;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlSelectQueryBlock;
 
 
-import com.google.common.collect.Sets;
-import org.nlpcn.es4sql.Util;
 import org.nlpcn.es4sql.domain.*;
-import org.nlpcn.es4sql.domain.Where.CONN;
 import org.nlpcn.es4sql.domain.hints.Hint;
 import org.nlpcn.es4sql.domain.hints.HintFactory;
 import org.nlpcn.es4sql.exception.SqlParseException;
-import org.nlpcn.es4sql.spatial.SpatialParamsFactory;
+
 
 /**
  * es sql support
@@ -25,7 +22,9 @@ import org.nlpcn.es4sql.spatial.SpatialParamsFactory;
  */
 public class SqlParser {
 
+
     public SqlParser() {
+
     }
 
     public Select parseSelect(SQLQueryExpr mySqlExpr) throws SqlParseException {
@@ -37,14 +36,17 @@ public class SqlParser {
         return select;
     }
 
-    private Select parseSelect(MySqlSelectQueryBlock query) throws SqlParseException {
+    public Select parseSelect(MySqlSelectQueryBlock query) throws SqlParseException {
+
         Select select = new Select();
+        WhereParser whereParser = new WhereParser(this, query);
+
 
         findSelect(query, select, query.getFrom().getAlias());
 
         select.getFrom().addAll(findFrom(query.getFrom()));
 
-        select.setWhere(findWhere(query.getWhere()));
+        select.setWhere(whereParser.findWhere());
 
         select.fillSubQueries();
 
@@ -60,412 +62,13 @@ public class SqlParser {
 
     public Delete parseDelete(SQLDeleteStatement deleteStatement) throws SqlParseException {
         Delete delete = new Delete();
+        WhereParser whereParser = new WhereParser(this, deleteStatement);
 
         delete.getFrom().addAll(findFrom(deleteStatement.getTableSource()));
 
-        delete.setWhere(findWhere(deleteStatement.getWhere()));
+        delete.setWhere(whereParser.findWhere());
 
         return delete;
-    }
-
-    private Where findWhere(SQLExpr where) throws SqlParseException {
-        if (where == null) {
-            return null;
-        }
-
-        Where myWhere = Where.newInstance();
-        parseWhere(where, myWhere);
-        return myWhere;
-    }
-
-    private boolean isCond(SQLBinaryOpExpr expr) {
-        SQLExpr leftSide = expr.getLeft();
-        if (leftSide instanceof SQLMethodInvokeExpr) {
-            return isAllowedMethodOnConditionLeft((SQLMethodInvokeExpr) leftSide, expr.getOperator());
-        }
-        return leftSide instanceof SQLIdentifierExpr || leftSide instanceof SQLPropertyExpr || leftSide instanceof SQLVariantRefExpr;
-    }
-
-    private boolean isAllowedMethodOnConditionLeft(SQLMethodInvokeExpr method, SQLBinaryOperator operator) {
-        return (method.getMethodName().toLowerCase().equals("nested") || method.getMethodName().toLowerCase().equals("children")) && !operator.isLogical();
-    }
-
-    public void parseWhere(SQLExpr expr, Where where) throws SqlParseException {
-
-
-
-        if (expr instanceof SQLBinaryOpExpr) {
-            SQLBinaryOpExpr bExpr = (SQLBinaryOpExpr) expr;
-            if (explanSpecialCondWithBothSidesAreLiterals(bExpr, where)) {
-                return;
-            }
-            if (explanSpecialCondWithBothSidesAreProperty(bExpr, where)) {
-                return;
-            }
-        }
-
-        if (expr instanceof SQLBinaryOpExpr && !isCond((SQLBinaryOpExpr) expr)) {
-            SQLBinaryOpExpr bExpr = (SQLBinaryOpExpr) expr;
-            routeCond(bExpr, bExpr.getLeft(), where);
-            routeCond(bExpr, bExpr.getRight(), where);
-        } else if (expr instanceof SQLNotExpr) {
-            parseWhere(((SQLNotExpr) expr).getExpr(), where);
-            negateWhere(where);
-        } else {
-            explanCond("AND", expr, where);
-        }
-    }
-
-    //some where conditions eg. 1=1 or 3>2 or 'a'='b'
-    private boolean explanSpecialCondWithBothSidesAreLiterals(SQLBinaryOpExpr bExpr, Where where) throws SqlParseException {
-        if ((bExpr.getLeft() instanceof SQLNumericLiteralExpr || bExpr.getLeft() instanceof SQLCharExpr) &&
-                (bExpr.getRight() instanceof SQLNumericLiteralExpr || bExpr.getRight() instanceof SQLCharExpr)
-                ) {
-            SQLMethodInvokeExpr sqlMethodInvokeExpr = new SQLMethodInvokeExpr("script", null);
-            String operator = bExpr.getOperator().getName();
-            if (operator.equals("=")) {
-                operator = "==";
-            }
-            sqlMethodInvokeExpr.addParameter(
-                    new SQLCharExpr(Util.expr2Object(bExpr.getLeft(), "'") +
-                            " " + operator + " " +
-                            Util.expr2Object(bExpr.getRight(), "'"))
-            );
-
-            explanCond("AND", sqlMethodInvokeExpr, where);
-            return true;
-        }
-        return false;
-    }
-
-    //some where conditions eg. field1=field2 or field1>field2
-    private boolean explanSpecialCondWithBothSidesAreProperty(SQLBinaryOpExpr bExpr, Where where) throws SqlParseException {
-        //join is not support
-        if ((bExpr.getLeft() instanceof SQLPropertyExpr || bExpr.getLeft() instanceof SQLIdentifierExpr) &&
-                (bExpr.getRight() instanceof SQLPropertyExpr || bExpr.getRight() instanceof SQLIdentifierExpr) &&
-                Sets.newHashSet("=", "<", ">", ">=", "<=").contains(bExpr.getOperator().getName()) &&
-                !Util.isFromJoinTable(bExpr)
-
-                ) {
-            SQLMethodInvokeExpr sqlMethodInvokeExpr = new SQLMethodInvokeExpr("script", null);
-            String operator = bExpr.getOperator().getName();
-            if (operator.equals("=")) {
-                operator = "==";
-            }
-
-            String leftProperty = Util.expr2Object(bExpr.getLeft()).toString();
-            String rightProperty = Util.expr2Object(bExpr.getRight()).toString();
-            if (leftProperty.split("\\.").length > 1) {
-
-                leftProperty = leftProperty.substring(leftProperty.split("\\.")[0].length()+1);
-            }
-
-            if (rightProperty.split("\\.").length > 1) {
-                rightProperty = rightProperty.substring(rightProperty.split("\\.")[0].length()+1);
-            }
-
-            sqlMethodInvokeExpr.addParameter(new SQLCharExpr(
-                    "doc['" + leftProperty + "'].value " +
-                            operator +
-                            " doc['" + rightProperty + "'].value"));
-
-
-            explanCond("AND", sqlMethodInvokeExpr, where);
-            return true;
-        }
-        return false;
-    }
-
-
-    private void routeCond(SQLBinaryOpExpr bExpr, SQLExpr sub, Where where) throws SqlParseException {
-        if (sub instanceof SQLBinaryOpExpr && !isCond((SQLBinaryOpExpr) sub)) {
-            SQLBinaryOpExpr binarySub = (SQLBinaryOpExpr) sub;
-            if (binarySub.getOperator().priority != bExpr.getOperator().priority) {
-                Where subWhere = new Where(bExpr.getOperator().name);
-                where.addWhere(subWhere);
-                parseWhere(binarySub, subWhere);
-            } else {
-                parseWhere(binarySub, where);
-            }
-        } else if (sub instanceof SQLNotExpr) {
-            Where subWhere = new Where(bExpr.getOperator().name);
-            where.addWhere(subWhere);
-            parseWhere(((SQLNotExpr) sub).getExpr(), subWhere);
-            negateWhere(subWhere);
-        } else {
-            explanCond(bExpr.getOperator().name, sub, where);
-        }
-    }
-
-    private void explanCond(String opear, SQLExpr expr, Where where) throws SqlParseException {
-        if (expr instanceof SQLBinaryOpExpr) {
-            SQLBinaryOpExpr soExpr = (SQLBinaryOpExpr) expr;
-            boolean methodAsOpear = false;
-
-            boolean isNested = false;
-            boolean isChildren = false;
-
-            NestedType nestedType = new NestedType();
-            if (nestedType.tryFillFromExpr(soExpr.getLeft())) {
-                soExpr.setLeft(new SQLIdentifierExpr(nestedType.field));
-                isNested = true;
-            }
-
-            ChildrenType childrenType = new ChildrenType();
-            if (childrenType.tryFillFromExpr(soExpr.getLeft())) {
-                soExpr.setLeft(new SQLIdentifierExpr(childrenType.field));
-                isChildren = true;
-            }
-
-            if (soExpr.getRight() instanceof SQLMethodInvokeExpr) {
-                SQLMethodInvokeExpr method = (SQLMethodInvokeExpr) soExpr.getRight();
-                String methodName = method.getMethodName().toLowerCase();
-
-                if (Condition.OPEAR.methodNameToOpear.containsKey(methodName)) {
-                    Object[] methodParametersValue = getMethodValuesWithSubQueries(method);
-
-                    Condition condition = null;
-
-                    if (isNested)
-                        condition = new Condition(CONN.valueOf(opear), soExpr.getLeft().toString(), Condition.OPEAR.methodNameToOpear.get(methodName), methodParametersValue, nestedType);
-                    else if (isChildren)
-                        condition = new Condition(CONN.valueOf(opear), soExpr.getLeft().toString(), Condition.OPEAR.methodNameToOpear.get(methodName), methodParametersValue, childrenType);
-                    else
-                        condition = new Condition(CONN.valueOf(opear), soExpr.getLeft().toString(), Condition.OPEAR.methodNameToOpear.get(methodName), methodParametersValue, null);
-
-                    where.addWhere(condition);
-                    methodAsOpear = true;
-                }
-            }
-
-            if (!methodAsOpear) {
-                Condition condition = null;
-
-                if (isNested)
-                    condition = new Condition(CONN.valueOf(opear), soExpr.getLeft().toString(), soExpr.getOperator().name, parseValue(soExpr.getRight()), nestedType);
-                else if (isChildren)
-                    condition = new Condition(CONN.valueOf(opear), soExpr.getLeft().toString(), soExpr.getOperator().name, parseValue(soExpr.getRight()), childrenType);
-                else
-                    condition = new Condition(CONN.valueOf(opear), soExpr.getLeft().toString(), soExpr.getOperator().name, parseValue(soExpr.getRight()), null);
-
-                where.addWhere(condition);
-            }
-        } else if (expr instanceof SQLInListExpr) {
-            SQLInListExpr siExpr = (SQLInListExpr) expr;
-            String leftSide = siExpr.getExpr().toString();
-
-            boolean isNested = false;
-            boolean isChildren = false;
-
-            NestedType nestedType = new NestedType();
-            if (nestedType.tryFillFromExpr(siExpr.getExpr())) {
-                leftSide = nestedType.field;
-
-                isNested = false;
-            }
-
-            ChildrenType childrenType = new ChildrenType();
-            if (childrenType.tryFillFromExpr(siExpr.getExpr())) {
-                leftSide = childrenType.field;
-
-                isChildren = true;
-            }
-
-            Condition condition = null;
-
-            if (isNested)
-                condition = new Condition(CONN.valueOf(opear), leftSide, siExpr.isNot() ? "NOT IN" : "IN", parseValue(siExpr.getTargetList()), nestedType);
-            else if (isChildren)
-                condition = new Condition(CONN.valueOf(opear), leftSide, siExpr.isNot() ? "NOT IN" : "IN", parseValue(siExpr.getTargetList()), childrenType);
-            else
-                condition = new Condition(CONN.valueOf(opear), leftSide, siExpr.isNot() ? "NOT IN" : "IN", parseValue(siExpr.getTargetList()), null);
-
-            where.addWhere(condition);
-        } else if (expr instanceof SQLBetweenExpr) {
-            SQLBetweenExpr between = ((SQLBetweenExpr) expr);
-            String leftSide = between.getTestExpr().toString();
-
-            boolean isNested = false;
-            boolean isChildren = false;
-
-            NestedType nestedType = new NestedType();
-            if (nestedType.tryFillFromExpr(between.getTestExpr())) {
-                leftSide = nestedType.field;
-
-                isNested = true;
-            }
-
-            ChildrenType childrenType = new ChildrenType();
-            if (childrenType.tryFillFromExpr(between.getTestExpr())) {
-                leftSide = childrenType.field;
-
-                isChildren = true;
-            }
-
-            Condition condition = null;
-
-            if (isNested)
-                condition = new Condition(CONN.valueOf(opear), leftSide, between.isNot() ? "NOT BETWEEN" : "BETWEEN", new Object[]{parseValue(between.beginExpr), parseValue(between.endExpr)}, nestedType);
-            else if (isChildren)
-                condition = new Condition(CONN.valueOf(opear), leftSide, between.isNot() ? "NOT BETWEEN" : "BETWEEN", new Object[]{parseValue(between.beginExpr), parseValue(between.endExpr)}, childrenType);
-            else
-                condition = new Condition(CONN.valueOf(opear), leftSide, between.isNot() ? "NOT BETWEEN" : "BETWEEN", new Object[]{parseValue(between.beginExpr), parseValue(between.endExpr)}, null);
-
-            where.addWhere(condition);
-        } else if (expr instanceof SQLMethodInvokeExpr) {
-
-            SQLMethodInvokeExpr methodExpr = (SQLMethodInvokeExpr) expr;
-            List<SQLExpr> methodParameters = methodExpr.getParameters();
-
-            String methodName = methodExpr.getMethodName();
-            if (SpatialParamsFactory.isAllowedMethod(methodName)) {
-                String fieldName = methodParameters.get(0).toString();
-
-                boolean isNested = false;
-                boolean isChildren = false;
-
-                NestedType nestedType = new NestedType();
-                if (nestedType.tryFillFromExpr(methodParameters.get(0))) {
-                    fieldName = nestedType.field;
-
-                    isNested = true;
-                }
-
-                ChildrenType childrenType = new ChildrenType();
-                if (childrenType.tryFillFromExpr(methodParameters.get(0))) {
-                    fieldName = childrenType.field;
-
-                    isChildren = true;
-                }
-
-                Object spatialParamsObject = SpatialParamsFactory.generateSpatialParamsObject(methodName, methodParameters);
-
-                Condition condition = null;
-
-                if (isNested)
-                    condition = new Condition(CONN.valueOf(opear), fieldName, methodName, spatialParamsObject, nestedType);
-                else if (isChildren)
-                    condition = new Condition(CONN.valueOf(opear), fieldName, methodName, spatialParamsObject, childrenType);
-                else
-                    condition = new Condition(CONN.valueOf(opear), fieldName, methodName, spatialParamsObject, null);
-
-                where.addWhere(condition);
-            } else if (methodName.toLowerCase().equals("nested")) {
-                NestedType nestedType = new NestedType();
-
-                if (!nestedType.tryFillFromExpr(expr)) {
-                    throw new SqlParseException("could not fill nested from expr:" + expr);
-                }
-
-                Condition condition = new Condition(CONN.valueOf(opear), nestedType.path, methodName.toUpperCase(), nestedType.where);
-
-                where.addWhere(condition);
-            } else if (methodName.toLowerCase().equals("children")) {
-                ChildrenType childrenType = new ChildrenType();
-
-                if (!childrenType.tryFillFromExpr(expr)) {
-                    throw new SqlParseException("could not fill children from expr:" + expr);
-                }
-
-                Condition condition = new Condition(CONN.valueOf(opear), childrenType.childType, methodName.toUpperCase(), childrenType.where);
-
-                where.addWhere(condition);
-            } else if (methodName.toLowerCase().equals("script")) {
-                ScriptFilter scriptFilter = new ScriptFilter();
-                if (!scriptFilter.tryParseFromMethodExpr(methodExpr)) {
-                    throw new SqlParseException("could not parse script filter");
-                }
-                Condition condition = new Condition(CONN.valueOf(opear), null, "SCRIPT", scriptFilter);
-                where.addWhere(condition);
-            } else {
-                throw new SqlParseException("unsupported method: " + methodName);
-            }
-        } else if (expr instanceof SQLInSubQueryExpr) {
-            SQLInSubQueryExpr sqlIn = (SQLInSubQueryExpr) expr;
-
-            Select innerSelect = parseSelect((MySqlSelectQueryBlock) sqlIn.getSubQuery().getQuery());
-
-            if (innerSelect.getFields() == null || innerSelect.getFields().size() != 1)
-                throw new SqlParseException("should only have one return field in subQuery");
-
-            SubQueryExpression subQueryExpression = new SubQueryExpression(innerSelect);
-
-            String leftSide = sqlIn.getExpr().toString();
-
-            boolean isNested = false;
-            boolean isChildren = false;
-
-            NestedType nestedType = new NestedType();
-            if (nestedType.tryFillFromExpr(sqlIn.getExpr())) {
-                leftSide = nestedType.field;
-
-                isNested = true;
-            }
-
-            ChildrenType childrenType = new ChildrenType();
-            if (childrenType.tryFillFromExpr(sqlIn.getExpr())) {
-                leftSide = childrenType.field;
-
-                isChildren = true;
-            }
-
-            Condition condition = null;
-
-            if (isNested)
-                condition = new Condition(CONN.valueOf(opear), leftSide, sqlIn.isNot() ? "NOT IN" : "IN", subQueryExpression, nestedType);
-            else if (isChildren)
-                condition = new Condition(CONN.valueOf(opear), leftSide, sqlIn.isNot() ? "NOT IN" : "IN", subQueryExpression, childrenType);
-            else
-                condition = new Condition(CONN.valueOf(opear), leftSide, sqlIn.isNot() ? "NOT IN" : "IN", subQueryExpression, null);
-
-            where.addWhere(condition);
-        } else {
-            throw new SqlParseException("err find condition " + expr.getClass());
-        }
-    }
-
-    private Object[] getMethodValuesWithSubQueries(SQLMethodInvokeExpr method) throws SqlParseException {
-        List<Object> values = new ArrayList<>();
-        for (SQLExpr innerExpr : method.getParameters()) {
-            if (innerExpr instanceof SQLQueryExpr) {
-                Select select = parseSelect((MySqlSelectQueryBlock) ((SQLQueryExpr) innerExpr).getSubQuery().getQuery());
-                values.add(new SubQueryExpression(select));
-            } else if (innerExpr instanceof SQLTextLiteralExpr) {
-                values.add(((SQLTextLiteralExpr) innerExpr).getText());
-            } else {
-                values.add(innerExpr);
-            }
-
-        }
-        return values.toArray();
-    }
-
-    private Object[] parseValue(List<SQLExpr> targetList) throws SqlParseException {
-        Object[] value = new Object[targetList.size()];
-        for (int i = 0; i < targetList.size(); i++) {
-            value[i] = parseValue(targetList.get(i));
-        }
-        return value;
-    }
-
-    private Object parseValue(SQLExpr expr) throws SqlParseException {
-        if (expr instanceof SQLNumericLiteralExpr) {
-            return ((SQLNumericLiteralExpr) expr).getNumber();
-        } else if (expr instanceof SQLCharExpr) {
-            return ((SQLCharExpr) expr).getText();
-        } else if (expr instanceof SQLMethodInvokeExpr) {
-            return expr;
-        } else if (expr instanceof SQLNullExpr) {
-            return null;
-        } else if (expr instanceof SQLIdentifierExpr) {
-            return expr;
-        } else if (expr instanceof SQLPropertyExpr) {
-            return expr;
-        } else {
-            throw new SqlParseException(
-                    String.format("Failed to parse SqlExpression of type %s. expression value: %s", expr.getClass(), expr)
-            );
-        }
     }
 
 
@@ -686,7 +289,8 @@ public class SqlParser {
         JoinSelect joinSelect = new JoinSelect();
         if (joinTableSource.getCondition() != null) {
             Where where = Where.newInstance();
-            parseWhere(joinTableSource.getCondition(), where);
+            WhereParser whereParser = new WhereParser(this, joinTableSource.getCondition());
+            whereParser.parseWhere(joinTableSource.getCondition(), where);
             joinSelect.setConnectedWhere(where);
         }
         SQLJoinTableSource.JoinType joinType = joinTableSource.getJoinType();
@@ -695,7 +299,8 @@ public class SqlParser {
     }
 
     private Map<String, Where> splitAndFindWhere(SQLExpr whereExpr, String firstTableAlias, String secondTableAlias) throws SqlParseException {
-        Where where = findWhere(whereExpr);
+        WhereParser whereParser = new WhereParser(this, whereExpr);
+        Where where = whereParser.findWhere();
         return splitWheres(where, firstTableAlias, secondTableAlias);
     }
 
@@ -739,7 +344,8 @@ public class SqlParser {
         List<Condition> conditions = new ArrayList<>();
         if (from.getCondition() == null) return conditions;
         Where where = Where.newInstance();
-        parseWhere(from.getCondition(), where);
+        WhereParser whereParser = new WhereParser(this, from.getCondition());
+        whereParser.parseWhere(from.getCondition(), where);
         addIfConditionRecursive(where, conditions);
         return conditions;
     }
@@ -819,16 +425,5 @@ public class SqlParser {
         return fromList;
     }
 
-    private void negateWhere(Where where) throws SqlParseException {
-        for (Where sub : where.getWheres()) {
-            if (sub instanceof Condition) {
-                Condition cond = (Condition) sub;
-                cond.setOpear(cond.getOpear().negative());
-            } else {
-                negateWhere(sub);
-            }
-            sub.setConn(sub.getConn().negative());
-        }
-    }
 
 }

--- a/src/main/java/org/nlpcn/es4sql/parse/WhereParser.java
+++ b/src/main/java/org/nlpcn/es4sql/parse/WhereParser.java
@@ -466,6 +466,14 @@ public class WhereParser {
         MethodField leftMethod = new MethodField(null, Lists.newArrayList(new KVValue("", Util.expr2Object(soExpr.getLeft(), "'"))), null, null);
         MethodField rightMethod = new MethodField(null, Lists.newArrayList(new KVValue("", Util.expr2Object(soExpr.getRight(), "'"))), null, null);
 
+        if(soExpr.getLeft() instanceof SQLIdentifierExpr || soExpr.getLeft() instanceof SQLPropertyExpr){
+            leftMethod = new MethodField(null, Lists.newArrayList(new KVValue("", "doc['"+Util.expr2Object(soExpr.getLeft(), "'")+"'].value")), null, null);
+        }
+
+        if(soExpr.getRight() instanceof SQLIdentifierExpr || soExpr.getRight() instanceof SQLPropertyExpr){
+            rightMethod = new MethodField(null, Lists.newArrayList(new KVValue("", "doc['"+Util.expr2Object(soExpr.getRight(), "'")+"'].value")), null, null);
+        }
+
         if (soExpr.getLeft() instanceof SQLMethodInvokeExpr) {
             leftMethod = parseSQLMethodInvokeExprWithFunctionInWhere((SQLMethodInvokeExpr) soExpr.getLeft());
         }

--- a/src/main/java/org/nlpcn/es4sql/parse/WhereParser.java
+++ b/src/main/java/org/nlpcn/es4sql/parse/WhereParser.java
@@ -1,0 +1,540 @@
+package org.nlpcn.es4sql.parse;
+
+import com.alibaba.druid.sql.ast.expr.*;
+import com.alibaba.druid.sql.ast.statement.*;
+import com.alibaba.druid.sql.ast.*;
+import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlSelectQueryBlock;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.nlpcn.es4sql.SQLFunctions;
+import org.nlpcn.es4sql.Util;
+import org.nlpcn.es4sql.domain.*;
+import org.nlpcn.es4sql.exception.SqlParseException;
+import org.nlpcn.es4sql.spatial.SpatialParamsFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by allwefantasy on 9/2/16.
+ */
+public class WhereParser {
+
+    private MySqlSelectQueryBlock query;
+    private SQLDeleteStatement delete;
+    private SQLExpr where;
+    private SqlParser sqlParser;
+
+    public WhereParser(SqlParser sqlParser, MySqlSelectQueryBlock query) {
+        this.sqlParser = sqlParser;
+        this.query = query;
+        this.where = query.getWhere();
+    }
+
+    public WhereParser(SqlParser sqlParser, SQLDeleteStatement delete) {
+        this.sqlParser = sqlParser;
+        this.delete = delete;
+        this.where = delete.getWhere();
+    }
+
+    public WhereParser(SqlParser sqlParser, SQLExpr expr) {
+        this.sqlParser = sqlParser;
+        this.where = expr;
+    }
+
+    public WhereParser(SqlParser sqlParser) {
+        this.sqlParser = sqlParser;
+    }
+
+    public Where findWhere() throws SqlParseException {
+        if (where == null) {
+            return null;
+        }
+
+        Where myWhere = Where.newInstance();
+        parseWhere(where, myWhere);
+        return myWhere;
+    }
+
+    public void parseWhere(SQLExpr expr, Where where) throws SqlParseException {
+
+
+        if (expr instanceof SQLBinaryOpExpr) {
+            SQLBinaryOpExpr bExpr = (SQLBinaryOpExpr) expr;
+            if (explanSpecialCondWithBothSidesAreLiterals(bExpr, where)) {
+                return;
+            }
+            if (explanSpecialCondWithBothSidesAreProperty(bExpr, where)) {
+                return;
+            }
+        }
+
+        if (expr instanceof SQLBinaryOpExpr && !isCond((SQLBinaryOpExpr) expr)) {
+            SQLBinaryOpExpr bExpr = (SQLBinaryOpExpr) expr;
+            routeCond(bExpr, bExpr.getLeft(), where);
+            routeCond(bExpr, bExpr.getRight(), where);
+        } else if (expr instanceof SQLNotExpr) {
+            parseWhere(((SQLNotExpr) expr).getExpr(), where);
+            negateWhere(where);
+        } else {
+            explanCond("AND", expr, where);
+        }
+    }
+
+    private void negateWhere(Where where) throws SqlParseException {
+        for (Where sub : where.getWheres()) {
+            if (sub instanceof Condition) {
+                Condition cond = (Condition) sub;
+                cond.setOpear(cond.getOpear().negative());
+            } else {
+                negateWhere(sub);
+            }
+            sub.setConn(sub.getConn().negative());
+        }
+    }
+
+    //some where conditions eg. 1=1 or 3>2 or 'a'='b'
+    private boolean explanSpecialCondWithBothSidesAreLiterals(SQLBinaryOpExpr bExpr, Where where) throws SqlParseException {
+        if ((bExpr.getLeft() instanceof SQLNumericLiteralExpr || bExpr.getLeft() instanceof SQLCharExpr) &&
+                (bExpr.getRight() instanceof SQLNumericLiteralExpr || bExpr.getRight() instanceof SQLCharExpr)
+                ) {
+            SQLMethodInvokeExpr sqlMethodInvokeExpr = new SQLMethodInvokeExpr("script", null);
+            String operator = bExpr.getOperator().getName();
+            if (operator.equals("=")) {
+                operator = "==";
+            }
+            sqlMethodInvokeExpr.addParameter(
+                    new SQLCharExpr(Util.expr2Object(bExpr.getLeft(), "'") +
+                            " " + operator + " " +
+                            Util.expr2Object(bExpr.getRight(), "'"))
+            );
+
+            explanCond("AND", sqlMethodInvokeExpr, where);
+            return true;
+        }
+        return false;
+    }
+
+    //some where conditions eg. field1=field2 or field1>field2
+    private boolean explanSpecialCondWithBothSidesAreProperty(SQLBinaryOpExpr bExpr, Where where) throws SqlParseException {
+        //join is not support
+        if ((bExpr.getLeft() instanceof SQLPropertyExpr || bExpr.getLeft() instanceof SQLIdentifierExpr) &&
+                (bExpr.getRight() instanceof SQLPropertyExpr || bExpr.getRight() instanceof SQLIdentifierExpr) &&
+                Sets.newHashSet("=", "<", ">", ">=", "<=").contains(bExpr.getOperator().getName()) &&
+                !Util.isFromJoinTable(bExpr)
+
+                ) {
+            SQLMethodInvokeExpr sqlMethodInvokeExpr = new SQLMethodInvokeExpr("script", null);
+            String operator = bExpr.getOperator().getName();
+            if (operator.equals("=")) {
+                operator = "==";
+            }
+
+            String leftProperty = Util.expr2Object(bExpr.getLeft()).toString();
+            String rightProperty = Util.expr2Object(bExpr.getRight()).toString();
+            if (leftProperty.split("\\.").length > 1) {
+
+                leftProperty = leftProperty.substring(leftProperty.split("\\.")[0].length() + 1);
+            }
+
+            if (rightProperty.split("\\.").length > 1) {
+                rightProperty = rightProperty.substring(rightProperty.split("\\.")[0].length() + 1);
+            }
+
+            sqlMethodInvokeExpr.addParameter(new SQLCharExpr(
+                    "doc['" + leftProperty + "'].value " +
+                            operator +
+                            " doc['" + rightProperty + "'].value"));
+
+
+            explanCond("AND", sqlMethodInvokeExpr, where);
+            return true;
+        }
+        return false;
+    }
+
+
+    private boolean isCond(SQLBinaryOpExpr expr) {
+        SQLExpr leftSide = expr.getLeft();
+        if (leftSide instanceof SQLMethodInvokeExpr) {
+            return isAllowedMethodOnConditionLeft((SQLMethodInvokeExpr) leftSide, expr.getOperator());
+        }
+        return leftSide instanceof SQLIdentifierExpr ||
+                leftSide instanceof SQLPropertyExpr ||
+                leftSide instanceof SQLVariantRefExpr;
+    }
+
+    private boolean isAllowedMethodOnConditionLeft(SQLMethodInvokeExpr method, SQLBinaryOperator operator) {
+        return (method.getMethodName().toLowerCase().equals("nested") ||
+                method.getMethodName().toLowerCase().equals("children") ||
+                SQLFunctions.buildInFunctions.contains(method.getMethodName().toLowerCase())
+        ) &&
+                !operator.isLogical();
+    }
+
+
+    private void routeCond(SQLBinaryOpExpr bExpr, SQLExpr sub, Where where) throws SqlParseException {
+        if (sub instanceof SQLBinaryOpExpr && !isCond((SQLBinaryOpExpr) sub)) {
+            SQLBinaryOpExpr binarySub = (SQLBinaryOpExpr) sub;
+            if (binarySub.getOperator().priority != bExpr.getOperator().priority) {
+                Where subWhere = new Where(bExpr.getOperator().name);
+                where.addWhere(subWhere);
+                parseWhere(binarySub, subWhere);
+            } else {
+                parseWhere(binarySub, where);
+            }
+        } else if (sub instanceof SQLNotExpr) {
+            Where subWhere = new Where(bExpr.getOperator().name);
+            where.addWhere(subWhere);
+            parseWhere(((SQLNotExpr) sub).getExpr(), subWhere);
+            negateWhere(subWhere);
+        } else {
+            explanCond(bExpr.getOperator().name, sub, where);
+        }
+    }
+
+    private void explanCond(String opear, SQLExpr expr, Where where) throws SqlParseException {
+        if (expr instanceof SQLBinaryOpExpr) {
+            SQLBinaryOpExpr soExpr = (SQLBinaryOpExpr) expr;
+            boolean methodAsOpear = false;
+
+            boolean isNested = false;
+            boolean isChildren = false;
+
+            NestedType nestedType = new NestedType();
+            if (nestedType.tryFillFromExpr(soExpr.getLeft())) {
+                soExpr.setLeft(new SQLIdentifierExpr(nestedType.field));
+                isNested = true;
+            }
+
+            ChildrenType childrenType = new ChildrenType();
+            if (childrenType.tryFillFromExpr(soExpr.getLeft())) {
+                soExpr.setLeft(new SQLIdentifierExpr(childrenType.field));
+                isChildren = true;
+            }
+
+            if (soExpr.getRight() instanceof SQLMethodInvokeExpr) {
+                SQLMethodInvokeExpr method = (SQLMethodInvokeExpr) soExpr.getRight();
+                String methodName = method.getMethodName().toLowerCase();
+
+                if (Condition.OPEAR.methodNameToOpear.containsKey(methodName)) {
+                    Object[] methodParametersValue = getMethodValuesWithSubQueries(method);
+
+                    Condition condition = null;
+
+                    if (isNested)
+                        condition = new Condition(Where.CONN.valueOf(opear), soExpr.getLeft().toString(), Condition.OPEAR.methodNameToOpear.get(methodName), methodParametersValue, nestedType);
+                    else if (isChildren)
+                        condition = new Condition(Where.CONN.valueOf(opear), soExpr.getLeft().toString(), Condition.OPEAR.methodNameToOpear.get(methodName), methodParametersValue, childrenType);
+                    else
+                        condition = new Condition(Where.CONN.valueOf(opear), soExpr.getLeft().toString(), Condition.OPEAR.methodNameToOpear.get(methodName), methodParametersValue, null);
+
+                    where.addWhere(condition);
+                    methodAsOpear = true;
+                }
+            }
+
+            if (!methodAsOpear) {
+                Condition condition = null;
+
+                if (isNested)
+                    condition = new Condition(Where.CONN.valueOf(opear), soExpr.getLeft().toString(), soExpr.getOperator().name, parseValue(soExpr.getRight()), nestedType);
+                else if (isChildren)
+                    condition = new Condition(Where.CONN.valueOf(opear), soExpr.getLeft().toString(), soExpr.getOperator().name, parseValue(soExpr.getRight()), childrenType);
+                else {
+                    SQLMethodInvokeExpr sqlMethodInvokeExpr = parseSQLBinaryOpExprWhoIsConditionInWhere(soExpr);
+                    if (sqlMethodInvokeExpr == null) {
+                        condition = new Condition(Where.CONN.valueOf(opear), soExpr.getLeft().toString(), soExpr.getOperator().name, parseValue(soExpr.getRight()), null);
+                    } else {
+                        ScriptFilter scriptFilter = new ScriptFilter();
+                        if (!scriptFilter.tryParseFromMethodExpr(sqlMethodInvokeExpr)) {
+                            throw new SqlParseException("could not parse script filter");
+                        }
+                        condition = new Condition(Where.CONN.valueOf(opear), null, "SCRIPT", scriptFilter);
+
+                    }
+
+                }
+                where.addWhere(condition);
+            }
+        } else if (expr instanceof SQLInListExpr) {
+            SQLInListExpr siExpr = (SQLInListExpr) expr;
+            String leftSide = siExpr.getExpr().toString();
+
+            boolean isNested = false;
+            boolean isChildren = false;
+
+            NestedType nestedType = new NestedType();
+            if (nestedType.tryFillFromExpr(siExpr.getExpr())) {
+                leftSide = nestedType.field;
+
+                isNested = false;
+            }
+
+            ChildrenType childrenType = new ChildrenType();
+            if (childrenType.tryFillFromExpr(siExpr.getExpr())) {
+                leftSide = childrenType.field;
+
+                isChildren = true;
+            }
+
+            Condition condition = null;
+
+            if (isNested)
+                condition = new Condition(Where.CONN.valueOf(opear), leftSide, siExpr.isNot() ? "NOT IN" : "IN", parseValue(siExpr.getTargetList()), nestedType);
+            else if (isChildren)
+                condition = new Condition(Where.CONN.valueOf(opear), leftSide, siExpr.isNot() ? "NOT IN" : "IN", parseValue(siExpr.getTargetList()), childrenType);
+            else
+                condition = new Condition(Where.CONN.valueOf(opear), leftSide, siExpr.isNot() ? "NOT IN" : "IN", parseValue(siExpr.getTargetList()), null);
+
+            where.addWhere(condition);
+        } else if (expr instanceof SQLBetweenExpr) {
+            SQLBetweenExpr between = ((SQLBetweenExpr) expr);
+            String leftSide = between.getTestExpr().toString();
+
+            boolean isNested = false;
+            boolean isChildren = false;
+
+            NestedType nestedType = new NestedType();
+            if (nestedType.tryFillFromExpr(between.getTestExpr())) {
+                leftSide = nestedType.field;
+
+                isNested = true;
+            }
+
+            ChildrenType childrenType = new ChildrenType();
+            if (childrenType.tryFillFromExpr(between.getTestExpr())) {
+                leftSide = childrenType.field;
+
+                isChildren = true;
+            }
+
+            Condition condition = null;
+
+            if (isNested)
+                condition = new Condition(Where.CONN.valueOf(opear), leftSide, between.isNot() ? "NOT BETWEEN" : "BETWEEN", new Object[]{parseValue(between.beginExpr), parseValue(between.endExpr)}, nestedType);
+            else if (isChildren)
+                condition = new Condition(Where.CONN.valueOf(opear), leftSide, between.isNot() ? "NOT BETWEEN" : "BETWEEN", new Object[]{parseValue(between.beginExpr), parseValue(between.endExpr)}, childrenType);
+            else
+                condition = new Condition(Where.CONN.valueOf(opear), leftSide, between.isNot() ? "NOT BETWEEN" : "BETWEEN", new Object[]{parseValue(between.beginExpr), parseValue(between.endExpr)}, null);
+
+            where.addWhere(condition);
+        } else if (expr instanceof SQLMethodInvokeExpr) {
+
+            SQLMethodInvokeExpr methodExpr = (SQLMethodInvokeExpr) expr;
+            List<SQLExpr> methodParameters = methodExpr.getParameters();
+
+            String methodName = methodExpr.getMethodName();
+            if (SpatialParamsFactory.isAllowedMethod(methodName)) {
+                String fieldName = methodParameters.get(0).toString();
+
+                boolean isNested = false;
+                boolean isChildren = false;
+
+                NestedType nestedType = new NestedType();
+                if (nestedType.tryFillFromExpr(methodParameters.get(0))) {
+                    fieldName = nestedType.field;
+
+                    isNested = true;
+                }
+
+                ChildrenType childrenType = new ChildrenType();
+                if (childrenType.tryFillFromExpr(methodParameters.get(0))) {
+                    fieldName = childrenType.field;
+
+                    isChildren = true;
+                }
+
+                Object spatialParamsObject = SpatialParamsFactory.generateSpatialParamsObject(methodName, methodParameters);
+
+                Condition condition = null;
+
+                if (isNested)
+                    condition = new Condition(Where.CONN.valueOf(opear), fieldName, methodName, spatialParamsObject, nestedType);
+                else if (isChildren)
+                    condition = new Condition(Where.CONN.valueOf(opear), fieldName, methodName, spatialParamsObject, childrenType);
+                else
+                    condition = new Condition(Where.CONN.valueOf(opear), fieldName, methodName, spatialParamsObject, null);
+
+                where.addWhere(condition);
+            } else if (methodName.toLowerCase().equals("nested")) {
+                NestedType nestedType = new NestedType();
+
+                if (!nestedType.tryFillFromExpr(expr)) {
+                    throw new SqlParseException("could not fill nested from expr:" + expr);
+                }
+
+                Condition condition = new Condition(Where.CONN.valueOf(opear), nestedType.path, methodName.toUpperCase(), nestedType.where);
+
+                where.addWhere(condition);
+            } else if (methodName.toLowerCase().equals("children")) {
+                ChildrenType childrenType = new ChildrenType();
+
+                if (!childrenType.tryFillFromExpr(expr)) {
+                    throw new SqlParseException("could not fill children from expr:" + expr);
+                }
+
+                Condition condition = new Condition(Where.CONN.valueOf(opear), childrenType.childType, methodName.toUpperCase(), childrenType.where);
+
+                where.addWhere(condition);
+            } else if (methodName.toLowerCase().equals("script")) {
+                ScriptFilter scriptFilter = new ScriptFilter();
+                if (!scriptFilter.tryParseFromMethodExpr(methodExpr)) {
+                    throw new SqlParseException("could not parse script filter");
+                }
+                Condition condition = new Condition(Where.CONN.valueOf(opear), null, "SCRIPT", scriptFilter);
+                where.addWhere(condition);
+            } else {
+                throw new SqlParseException("unsupported method: " + methodName);
+            }
+        } else if (expr instanceof SQLInSubQueryExpr) {
+            SQLInSubQueryExpr sqlIn = (SQLInSubQueryExpr) expr;
+
+            Select innerSelect = sqlParser.parseSelect((MySqlSelectQueryBlock) sqlIn.getSubQuery().getQuery());
+
+            if (innerSelect.getFields() == null || innerSelect.getFields().size() != 1)
+                throw new SqlParseException("should only have one return field in subQuery");
+
+            SubQueryExpression subQueryExpression = new SubQueryExpression(innerSelect);
+
+            String leftSide = sqlIn.getExpr().toString();
+
+            boolean isNested = false;
+            boolean isChildren = false;
+
+            NestedType nestedType = new NestedType();
+            if (nestedType.tryFillFromExpr(sqlIn.getExpr())) {
+                leftSide = nestedType.field;
+
+                isNested = true;
+            }
+
+            ChildrenType childrenType = new ChildrenType();
+            if (childrenType.tryFillFromExpr(sqlIn.getExpr())) {
+                leftSide = childrenType.field;
+
+                isChildren = true;
+            }
+
+            Condition condition = null;
+
+            if (isNested)
+                condition = new Condition(Where.CONN.valueOf(opear), leftSide, sqlIn.isNot() ? "NOT IN" : "IN", subQueryExpression, nestedType);
+            else if (isChildren)
+                condition = new Condition(Where.CONN.valueOf(opear), leftSide, sqlIn.isNot() ? "NOT IN" : "IN", subQueryExpression, childrenType);
+            else
+                condition = new Condition(Where.CONN.valueOf(opear), leftSide, sqlIn.isNot() ? "NOT IN" : "IN", subQueryExpression, null);
+
+            where.addWhere(condition);
+        } else {
+            throw new SqlParseException("err find condition " + expr.getClass());
+        }
+    }
+
+    private MethodField parseSQLMethodInvokeExprWithFunctionInWhere(SQLMethodInvokeExpr soExpr) throws SqlParseException {
+
+        MethodField methodField = FieldMaker.makeMethodField(soExpr.getMethodName(),
+                soExpr.getParameters(),
+                null,
+                null,
+                query == null ? query.getFrom().getAlias() : null,
+                false);
+        return methodField;
+    }
+
+    private SQLMethodInvokeExpr parseSQLBinaryOpExprWhoIsConditionInWhere(SQLBinaryOpExpr soExpr) throws SqlParseException {
+
+        if (!(soExpr.getLeft() instanceof SQLMethodInvokeExpr ||
+                soExpr.getRight() instanceof SQLMethodInvokeExpr)) {
+            return null;
+        }
+
+        if (soExpr.getLeft() instanceof SQLMethodInvokeExpr) {
+            if (!SQLFunctions.buildInFunctions.contains(((SQLMethodInvokeExpr) soExpr.getLeft()).getMethodName())) {
+                return null;
+            }
+        }
+
+        if (soExpr.getRight() instanceof SQLMethodInvokeExpr) {
+            if (!SQLFunctions.buildInFunctions.contains(((SQLMethodInvokeExpr) soExpr.getRight()).getMethodName())) {
+                return null;
+            }
+        }
+
+
+        MethodField leftMethod = new MethodField(null, Lists.newArrayList(new KVValue("", Util.expr2Object(soExpr.getLeft(), "'"))), null, null);
+        MethodField rightMethod = new MethodField(null, Lists.newArrayList(new KVValue("", Util.expr2Object(soExpr.getRight(), "'"))), null, null);
+
+        if (soExpr.getLeft() instanceof SQLMethodInvokeExpr) {
+            leftMethod = parseSQLMethodInvokeExprWithFunctionInWhere((SQLMethodInvokeExpr) soExpr.getLeft());
+        }
+        if (soExpr.getRight() instanceof SQLMethodInvokeExpr) {
+            rightMethod = parseSQLMethodInvokeExprWithFunctionInWhere((SQLMethodInvokeExpr) soExpr.getRight());
+        }
+
+        String v1 = leftMethod.getParams().get(0).value.toString();
+        String v1Dec = leftMethod.getParams().size() == 2 ? leftMethod.getParams().get(1).value.toString() + ";" : "";
+
+
+        String v2 = rightMethod.getParams().get(0).value.toString();
+        String v2Dec = rightMethod.getParams().size() == 2 ? rightMethod.getParams().get(1).value.toString() + ";" : "";
+
+        String operator = soExpr.getOperator().getName();
+
+        if (operator.equals("=")) {
+            operator = "==";
+        }
+
+        String finalStr = v1Dec + v2Dec + v1 + " " + operator + " " + v2;
+
+        SQLMethodInvokeExpr scriptMethod = new SQLMethodInvokeExpr("script", null);
+        scriptMethod.addParameter(new SQLCharExpr(finalStr));
+        return scriptMethod;
+
+    }
+
+    private Object[] getMethodValuesWithSubQueries(SQLMethodInvokeExpr method) throws SqlParseException {
+        List<Object> values = new ArrayList<>();
+        for (SQLExpr innerExpr : method.getParameters()) {
+            if (innerExpr instanceof SQLQueryExpr) {
+                Select select = sqlParser.parseSelect((MySqlSelectQueryBlock) ((SQLQueryExpr) innerExpr).getSubQuery().getQuery());
+                values.add(new SubQueryExpression(select));
+            } else if (innerExpr instanceof SQLTextLiteralExpr) {
+                values.add(((SQLTextLiteralExpr) innerExpr).getText());
+            } else {
+                values.add(innerExpr);
+            }
+
+        }
+        return values.toArray();
+    }
+
+    private Object[] parseValue(List<SQLExpr> targetList) throws SqlParseException {
+        Object[] value = new Object[targetList.size()];
+        for (int i = 0; i < targetList.size(); i++) {
+            value[i] = parseValue(targetList.get(i));
+        }
+        return value;
+    }
+
+    private Object parseValue(SQLExpr expr) throws SqlParseException {
+        if (expr instanceof SQLNumericLiteralExpr) {
+            return ((SQLNumericLiteralExpr) expr).getNumber();
+        } else if (expr instanceof SQLCharExpr) {
+            return ((SQLCharExpr) expr).getText();
+        } else if (expr instanceof SQLMethodInvokeExpr) {
+            return expr;
+        } else if (expr instanceof SQLNullExpr) {
+            return null;
+        } else if (expr instanceof SQLIdentifierExpr) {
+            return expr;
+        } else if (expr instanceof SQLPropertyExpr) {
+            return expr;
+        } else {
+            throw new SqlParseException(
+                    String.format("Failed to parse SqlExpression of type %s. expression value: %s", expr.getClass(), expr)
+            );
+        }
+    }
+}

--- a/src/test/java/org/nlpcn/es4sql/SQLFunctionsTest.java
+++ b/src/test/java/org/nlpcn/es4sql/SQLFunctionsTest.java
@@ -164,6 +164,27 @@ public class SQLFunctionsTest {
         Assert.assertTrue(contents.size() == 223);
     }
 
+    @Test
+    public void whereConditionLeftFunctionRightPropertyGreatTest() throws Exception {
+
+        String query = "SELECT " +
+                " * from " +
+                TestsConstants.TEST_INDEX + "/account " +
+                " where floor(split(address,' ')[0]+0) > b limit 1000  ";
+
+        Select select = parser.parseSelect((SQLQueryExpr) queryToExpr(query));
+        Where where = select.getWhere();
+        Assert.assertTrue((where.getWheres().size() == 1));
+        Assert.assertTrue(((Condition) (where.getWheres().get(0))).getValue() instanceof ScriptFilter);
+        ScriptFilter scriptFilter = (ScriptFilter) (((Condition) (where.getWheres().get(0))).getValue());
+
+        Assert.assertTrue(scriptFilter.getScript().contains("doc['address'].value.split(' ')[0]"));
+        Pattern pattern = Pattern.compile("floor_\\d+ > doc\\['b'\\].value");
+        Matcher matcher = pattern.matcher(scriptFilter.getScript());
+        Assert.assertTrue(matcher.find());
+
+    }
+
     private SQLExpr queryToExpr(String query) {
         return new ElasticSqlExprParser(query).expr();
     }


### PR DESCRIPTION
## requirement

ES should make groovy script enable.

## Example

```
select * from t where floor(split(address,' ')[0]+0) > age
select * from t where floor(split(address,' ')[0]+0) > floor(split(address2,' ')[0]+0)
select * from t where floor(split(address,' ')[0]) > floor(split(address2,' ')[0])
```

## UnitTest

```
org.nlpcn.es4sql.SQLFunctionsTest.whereConditionLeftFunctionRightVariableEqualTest
org.nlpcn.es4sql.SQLFunctionsTest.whereConditionLeftFunctionRightVariableGreatTest
org.nlpcn.es4sql.SQLFunctionsTest.whereConditionLeftFunctionRightPropertyGreatTest
```