### PR TITLE
fix bug in aggregation query when select has script

### DIFF
--- a/src/main/java/org/nlpcn/es4sql/query/AggregationQueryAction.java
+++ b/src/main/java/org/nlpcn/es4sql/query/AggregationQueryAction.java
@@ -100,9 +100,7 @@ public class AggregationQueryAction extends QueryAction {
 
                 for (int i = 1; i < groupBy.size(); i++) {
                     field = groupBy.get(i);
-					AggregationBuilder<?> subAgg = getGroupAgg(field, select);
-					
-                    AggregationBuilder<?> subAgg = aggMaker.makeGroupAgg(field);
+                    AggregationBuilder<?> subAgg = getGroupAgg(field, select);
                     if (subAgg instanceof TermsBuilder && !(field instanceof MethodField)) {
                         ((TermsBuilder) subAgg).size(0);
                     }

--- a/src/main/java/org/nlpcn/es4sql/query/AggregationQueryAction.java
+++ b/src/main/java/org/nlpcn/es4sql/query/AggregationQueryAction.java
@@ -59,9 +59,6 @@ public class AggregationQueryAction extends QueryAction {
                 //make groupby can reference to field alias
                 lastAgg = getGroupAgg(field, select);
 
-                if (!refrence) lastAgg = aggMaker.makeGroupAgg(field);
-
-
                 if (lastAgg != null && lastAgg instanceof TermsBuilder && !(field instanceof MethodField)) {
                     //if limit size is too small, increasing shard  size is required
                     if (select.getRowCount() < 200) {

--- a/src/test/java/org/nlpcn/es4sql/ExplainTest.java
+++ b/src/test/java/org/nlpcn/es4sql/ExplainTest.java
@@ -28,6 +28,14 @@ public class ExplainTest {
 
 		assertThat(result, equalTo(expectedOutput));
 	}
+	
+    @Test
+    public void aggregationQuery() throws IOException, SqlParseException, NoSuchMethodException, IllegalAccessException, SQLFeatureNotSupportedException, InvocationTargetException {
+        String expectedOutput = Files.toString(new File("src/test/resources/expectedOutput/aggregation_query_explain.json"), StandardCharsets.UTF_8).replaceAll("\r","");
+        String result = explain(String.format("SELECT a, CASE WHEN gender='0' then 'aaa' else 'bbb'end a2345,count(c) FROM %s GROUP BY terms('field'='a'),a2345", TEST_INDEX));
+
+        assertThat(result, equalTo(expectedOutput));
+    }
 
 	@Test
 	public void searchSanityFilter() throws IOException, SqlParseException, NoSuchMethodException, IllegalAccessException, SQLFeatureNotSupportedException, InvocationTargetException {

--- a/src/test/resources/expectedOutput/aggregation_query_explain.json
+++ b/src/test/resources/expectedOutput/aggregation_query_explain.json
@@ -1,0 +1,40 @@
+{
+  "from" : 0,
+  "size" : 0,
+  "_source" : {
+    "includes" : [ ],
+    "excludes" : [ ]
+  },
+  "fields" : [ "a", "a2345" ],
+  "script_fields" : {
+    "a2345" : {
+      "script" : {
+        "inline" : "if( (doc['gender'].value=='0')){'aaa'} else {'bbb'}"
+      }
+    }
+  },
+  "aggregations" : {
+    "terms(field=a)" : {
+      "terms" : {
+        "field" : "a"
+      },
+      "aggregations" : {
+        "a2345" : {
+          "terms" : {
+            "script" : {
+              "inline" : "if( (doc['gender'].value=='0')){'aaa'} else {'bbb'}"
+            },
+            "size" : 0
+          },
+          "aggregations" : {
+            "COUNT(c)" : {
+              "value_count" : {
+                "field" : "c"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
There is a bug where sql is "SELECT a, CASE WHEN gender='0' then 'aaa' else 'bbb'end a2345,count(c) FROM %s GROUP BY terms('field'='a'),a2345", the group field should find reference field in select