### PR TITLE
An empty set is returned when there is no result data

### DIFF
--- a/src/main/java/org/nlpcn/es4sql/jdbc/ObjectResultsExtractor.java
+++ b/src/main/java/org/nlpcn/es4sql/jdbc/ObjectResultsExtractor.java
@@ -46,7 +46,11 @@ public class ObjectResultsExtractor {
             List<List<Object>> lines = new ArrayList<>();
             lines.add(new ArrayList<Object>());
             handleAggregations((Aggregations) queryResult, headers, lines);
-
+            
+            // remove empty line。
+            if(lines.get(0).size() == 0) {
+                lines.remove(0);
+            }
             //todo: need to handle more options for aggregations:
             //Aggregations that inhrit from base
             //ScriptedMetric


### PR DESCRIPTION
If not . you may get a blank line when you invoke rs.next().