### PR TITLE
fix bug and add function for "case when"

### DIFF
--- a/src/main/java/org/nlpcn/es4sql/Util.java
+++ b/src/main/java/org/nlpcn/es4sql/Util.java
@@ -99,6 +99,8 @@ public class Util {
             return ((SQLIntegerExpr) expr).getValue();
         } else if (expr instanceof SQLNumericLiteralExpr) {
             return ((SQLNumericLiteralExpr) expr).getNumber();
+        } else if (expr instanceof SQLNullExpr) {
+            return ((SQLNullExpr) expr).toString().toLowerCase();
         }
         throw new SqlParseException("could not parse sqlBinaryOpExpr need to be identifier/valuable got" + expr.getClass().toString() + " with value:" + expr.toString());
     }

--- a/src/main/java/org/nlpcn/es4sql/parse/CaseWhenParser.java
+++ b/src/main/java/org/nlpcn/es4sql/parse/CaseWhenParser.java
@@ -2,6 +2,7 @@ package org.nlpcn.es4sql.parse;
 
 import com.alibaba.druid.sql.ast.SQLExpr;
 import com.alibaba.druid.sql.ast.expr.SQLCaseExpr;
+import com.alibaba.druid.sql.ast.expr.SQLNullExpr;
 import com.google.common.base.Joiner;
 import org.elasticsearch.common.inject.internal.Join;
 import org.nlpcn.es4sql.SQLFunctions;
@@ -75,7 +76,13 @@ public class CaseWhenParser {
             if (condition.getValue() instanceof ScriptFilter) {
                 codes.add(relation + "(" + ((ScriptFilter) condition.getValue()).getScript() + ")");
             } else {
-                codes.add(relation + "(" + Util.getScriptValueWithQuote(condition.getNameExpr(), "'") + condition.getOpertatorSymbol() + Util.getScriptValueWithQuote(condition.getValueExpr(), "'") + ")");
+                SQLExpr nameExpr = condition.getNameExpr();
+                SQLExpr valueExpr = condition.getValueExpr();
+                if(valueExpr instanceof SQLNullExpr) {
+                    codes.add(relation + "(" + "doc['" + nameExpr.toString() + "']" + ".empty)");
+                } else {
+                    codes.add(relation + "(" + Util.getScriptValueWithQuote(nameExpr, "'") + condition.getOpertatorSymbol() + Util.getScriptValueWithQuote(valueExpr, "'") + ")");
+                }
             }
         } else {
             for (Where subWhere : where.getWheres()) {

--- a/src/main/java/org/nlpcn/es4sql/query/AggregationQueryAction.java
+++ b/src/main/java/org/nlpcn/es4sql/query/AggregationQueryAction.java
@@ -178,9 +178,10 @@ public class AggregationQueryAction extends QueryAction {
         SqlElasticSearchRequestBuilder sqlElasticRequestBuilder = new SqlElasticSearchRequestBuilder(request);
         return sqlElasticRequestBuilder;
     }
-	private AggregationBuilder<?> getGroupAgg(Field field, Select select2) throws SqlParseException {
-    	boolean refrence = false;
-    	AggregationBuilder<?> lastAgg = null;
+    
+    private AggregationBuilder<?> getGroupAgg(Field field, Select select2) throws SqlParseException {
+        boolean refrence = false;
+        AggregationBuilder<?> lastAgg = null;
         for (Field temp : select.getFields()) {
             if (temp instanceof MethodField && temp.getName().equals("script")) {
                 MethodField scriptField = (MethodField) temp;
@@ -197,7 +198,7 @@ public class AggregationQueryAction extends QueryAction {
         if (!refrence) lastAgg = aggMaker.makeGroupAgg(field);
         
         return lastAgg;
-	}
+    }
 
     private AbstractAggregationBuilder wrapNestedIfNeeded(AggregationBuilder nestedBuilder, boolean reverseNested) {
         if (!reverseNested) return nestedBuilder;

--- a/src/test/java/org/nlpcn/es4sql/ExplainTest.java
+++ b/src/test/java/org/nlpcn/es4sql/ExplainTest.java
@@ -21,14 +21,14 @@ import static org.hamcrest.Matchers.*;
 
 public class ExplainTest {
 
-	@Test
-	public void searchSanity() throws IOException, SqlParseException, NoSuchMethodException, IllegalAccessException, SQLFeatureNotSupportedException, InvocationTargetException {
-		String expectedOutput = Files.toString(new File("src/test/resources/expectedOutput/search_explain.json"), StandardCharsets.UTF_8).replaceAll("\r","");
-		String result = explain(String.format("SELECT * FROM %s WHERE firstname LIKE 'A%%' AND age > 20 GROUP BY gender order by _score", TEST_INDEX));
+    @Test
+    public void searchSanity() throws IOException, SqlParseException, NoSuchMethodException, IllegalAccessException, SQLFeatureNotSupportedException, InvocationTargetException {
+        String expectedOutput = Files.toString(new File("src/test/resources/expectedOutput/search_explain.json"), StandardCharsets.UTF_8).replaceAll("\r","");
+        String result = explain(String.format("SELECT * FROM %s WHERE firstname LIKE 'A%%' AND age > 20 GROUP BY gender order by _score", TEST_INDEX));
 
-		assertThat(result, equalTo(expectedOutput));
-	}
-	
+        assertThat(result, equalTo(expectedOutput));
+    }
+    
     @Test
     public void aggregationQuery() throws IOException, SqlParseException, NoSuchMethodException, IllegalAccessException, SQLFeatureNotSupportedException, InvocationTargetException {
         String expectedOutput = Files.toString(new File("src/test/resources/expectedOutput/aggregation_query_explain.json"), StandardCharsets.UTF_8).replaceAll("\r","");
@@ -36,22 +36,30 @@ public class ExplainTest {
 
         assertThat(result, equalTo(expectedOutput));
     }
+    
+    @Test
+    public void explainScriptValue() throws IOException, SqlParseException, NoSuchMethodException, IllegalAccessException, SQLFeatureNotSupportedException, InvocationTargetException {
+        String expectedOutput = Files.toString(new File("src/test/resources/expectedOutput/script_value.json"), StandardCharsets.UTF_8).replaceAll("\r","");
+        String result = explain(String.format("SELECT  case when gender is null then 'aaa'  else gender  end  test , cust_code FROM %s", TEST_INDEX));
 
-	@Test
-	public void searchSanityFilter() throws IOException, SqlParseException, NoSuchMethodException, IllegalAccessException, SQLFeatureNotSupportedException, InvocationTargetException {
-		String expectedOutput = Files.toString(new File("src/test/resources/expectedOutput/search_explain_filter.json"), StandardCharsets.UTF_8).replaceAll("\r","");
-		String result = explain(String.format("SELECT * FROM %s WHERE firstname LIKE 'A%%' AND age > 20 GROUP BY gender", TEST_INDEX));
+        assertThat(result, equalTo(expectedOutput));
+    }
 
-		assertThat(result, equalTo(expectedOutput));
-	}
+    @Test
+    public void searchSanityFilter() throws IOException, SqlParseException, NoSuchMethodException, IllegalAccessException, SQLFeatureNotSupportedException, InvocationTargetException {
+        String expectedOutput = Files.toString(new File("src/test/resources/expectedOutput/search_explain_filter.json"), StandardCharsets.UTF_8).replaceAll("\r","");
+        String result = explain(String.format("SELECT * FROM %s WHERE firstname LIKE 'A%%' AND age > 20 GROUP BY gender", TEST_INDEX));
 
-	@Test
-	public void deleteSanity() throws IOException, SqlParseException, NoSuchMethodException, IllegalAccessException, SQLFeatureNotSupportedException, InvocationTargetException {
-		String expectedOutput = Files.toString(new File("src/test/resources/expectedOutput/delete_explain.json"), StandardCharsets.UTF_8).replaceAll("\r","");;
-		String result = explain(String.format("DELETE FROM %s WHERE firstname LIKE 'A%%' AND age > 20", TEST_INDEX));
+        assertThat(result, equalTo(expectedOutput));
+    }
 
-		assertThat(result, equalTo(expectedOutput));
-	}
+    @Test
+    public void deleteSanity() throws IOException, SqlParseException, NoSuchMethodException, IllegalAccessException, SQLFeatureNotSupportedException, InvocationTargetException {
+        String expectedOutput = Files.toString(new File("src/test/resources/expectedOutput/delete_explain.json"), StandardCharsets.UTF_8).replaceAll("\r","");;
+        String result = explain(String.format("DELETE FROM %s WHERE firstname LIKE 'A%%' AND age > 20", TEST_INDEX));
+
+        assertThat(result, equalTo(expectedOutput));
+    }
 
     @Test
     public void spatialFilterExplainTest() throws IOException, SqlParseException, NoSuchMethodException, IllegalAccessException, SQLFeatureNotSupportedException, InvocationTargetException {
@@ -61,8 +69,8 @@ public class ExplainTest {
     }
 
     private String explain(String sql) throws SQLFeatureNotSupportedException, SqlParseException, InvocationTargetException, NoSuchMethodException, IllegalAccessException, IOException {
-		SearchDao searchDao = MainTestSuite.getSearchDao();
+        SearchDao searchDao = MainTestSuite.getSearchDao();
         SqlElasticRequestBuilder requestBuilder = searchDao.explain(sql).explain();
         return requestBuilder.explain();
-	}
+    }
 }

--- a/src/test/java/org/nlpcn/es4sql/ExplainTest.java
+++ b/src/test/java/org/nlpcn/es4sql/ExplainTest.java
@@ -44,6 +44,14 @@ public class ExplainTest {
 
         assertThat(result, equalTo(expectedOutput));
     }
+    
+    @Test
+    public void betweenScriptValue() throws IOException, SqlParseException, NoSuchMethodException, IllegalAccessException, SQLFeatureNotSupportedException, InvocationTargetException {
+        String expectedOutput = Files.toString(new File("src/test/resources/expectedOutput/between_query.json"), StandardCharsets.UTF_8).replaceAll("\r","");
+        String result = explain(String.format("SELECT  case when value between 100 and 200 then 'aaa'  else value  end  test , cust_code FROM %s", TEST_INDEX));
+
+        assertThat(result, equalTo(expectedOutput));
+    }
 
     @Test
     public void searchSanityFilter() throws IOException, SqlParseException, NoSuchMethodException, IllegalAccessException, SQLFeatureNotSupportedException, InvocationTargetException {

--- a/src/test/resources/expectedOutput/aggregation_query_explain.json
+++ b/src/test/resources/expectedOutput/aggregation_query_explain.json
@@ -9,7 +9,7 @@
   "script_fields" : {
     "a2345" : {
       "script" : {
-        "inline" : "if( (doc['gender'].value=='0')){'aaa'} else {'bbb'}"
+        "inline" : "if((doc['gender'].value=='0')){'aaa'} else {'bbb'}"
       }
     }
   },
@@ -22,7 +22,7 @@
         "a2345" : {
           "terms" : {
             "script" : {
-              "inline" : "if( (doc['gender'].value=='0')){'aaa'} else {'bbb'}"
+              "inline" : "if((doc['gender'].value=='0')){'aaa'} else {'bbb'}"
             },
             "size" : 0
           },

--- a/src/test/resources/expectedOutput/between_query.json
+++ b/src/test/resources/expectedOutput/between_query.json
@@ -8,7 +8,7 @@
   "script_fields" : {
     "test" : {
       "script" : {
-        "inline" : "if((doc['gender'].empty)){'aaa'} else {doc['gender'].value}"
+        "inline" : "if((doc['value'].value >= 100 && doc['value'].value <=200)){'aaa'} else {doc['value'].value}"
       }
     }
   }

--- a/src/test/resources/expectedOutput/script_value.json
+++ b/src/test/resources/expectedOutput/script_value.json
@@ -8,7 +8,7 @@
   "script_fields" : {
     "test" : {
       "script" : {
-        "inline" : "if( (doc['gender'].value==null)){'aaa'} else {doc['gender'].value}"
+        "inline" : "if( (doc['gender'].empty)){'aaa'} else {doc['gender'].value}"
       }
     }
   }

--- a/src/test/resources/expectedOutput/script_value.json
+++ b/src/test/resources/expectedOutput/script_value.json
@@ -1,0 +1,15 @@
+{
+  "from" : 0,
+  "size" : 200,
+  "_source" : {
+    "includes" : [ "cust_code" ],
+    "excludes" : [ ]
+  },
+  "script_fields" : {
+    "test" : {
+      "script" : {
+        "inline" : "if( (doc['gender'].value==null)){'aaa'} else {doc['gender'].value}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
1. fix bug in "case when" while value is null, for example the sql is "SELECT case when gender is null then 'aaa' else gender end test , aa FROM table"
2. change to user doc['field'].empty if there is null in script, because doc['field'].value will return 0 if it is not string
3. fix bug when there is "and" in "case when" and add for support between