### PR TITLE
README: Fix build status heading [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Elasticsearch-SQL
 =================
-###build status
+
+### build status
+
 **master** [![1.X Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=master)](https://travis-ci.org/NLPchina/elasticsearch-sql)
 **2.0.0** [![2.0.0 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.0)](https://travis-ci.org/NLPchina/elasticsearch-sql)
 **2.1.0** [![2.1.0 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic2.1)](https://travis-ci.org/NLPchina/elasticsearch-sql)


### PR DESCRIPTION
This PR fixes a Markdown typo in the readme, so that the "build status" heading renders as a headline.