### PR TITLE
让ElasticSearchResultSetMetaDataBase可以获取到列的metadata信息

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/ElasticSearchResultSetMetaDataBase.java
+++ b/src/main/java/com/alibaba/druid/pool/ElasticSearchResultSetMetaDataBase.java
@@ -1,15 +1,16 @@
 package com.alibaba.druid.pool;
 
-import com.alibaba.druid.util.jdbc.ResultSetBase;
-import com.alibaba.druid.util.jdbc.ResultSetMetaDataBase;
-
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+
+import com.alibaba.druid.util.jdbc.ResultSetMetaDataBase;
 
 /**
  * Created by allwefantasy on 8/31/16.
  */
 public class ElasticSearchResultSetMetaDataBase extends ResultSetMetaDataBase {
+	
     private final List<ColumnMetaData> columns = new ArrayList<ColumnMetaData>();
 
     public ElasticSearchResultSetMetaDataBase(List<String> headers) {
@@ -20,4 +21,16 @@ public class ElasticSearchResultSetMetaDataBase extends ResultSetMetaDataBase {
             columns.add(columnMetaData);
         }
     }
+    
+    @Override
+    public List<ColumnMetaData> getColumns() {
+        return columns;
+    }
+    
+    @Override
+    public int getColumnCount() throws SQLException {
+        return columns.size();
+    }
+    
+    
 }


### PR DESCRIPTION
解决JDBC中无法获取metadata的问题