### PR TITLE
fix 使用jdbc调用metaData.getColumnCount()函数无法获取正常列数信息的问题 #751

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/ElasticSearchResultSetMetaDataBase.java
+++ b/src/main/java/com/alibaba/druid/pool/ElasticSearchResultSetMetaDataBase.java
@@ -10,7 +10,7 @@ import java.util.List;
  * Created by allwefantasy on 8/31/16.
  */
 public class ElasticSearchResultSetMetaDataBase extends ResultSetMetaDataBase {
-    private final List<ColumnMetaData> columns = new ArrayList<ColumnMetaData>();
+    private final List<ColumnMetaData> columns = super.getColumns();
 
     public ElasticSearchResultSetMetaDataBase(List<String> headers) {
         for(String column:headers){


### PR DESCRIPTION
ElasticSearchResultSetMetaDataBase类中使用语句：
   private final List<ColumnMetaData> columns = new ArrayList<ColumnMetaData>();
建立了自己的columns，但是并没有重写。但是其父类中已经创建了columns，由于ElasticSearchResultSetMetaDataBase类没有重写getColumnCount等函数，调用者使用相关功能时，实际上使用的是父类的columns对象，而非子类新创建的对象，从而导致无法获取列数等信息的问题。

本次修改在初始化columns时，直接使用父类已经初始化好的对象，统一父类与子类方法中的对象信息，修复该问题。并在本地测试环境中进行了验证。