### PR TITLE
fix bug#connection in druid infinitely increased

### DIFF
--- a/src/main/java/com/alibaba/druid/pool/ElasticSearchConnection.java
+++ b/src/main/java/com/alibaba/druid/pool/ElasticSearchConnection.java
@@ -23,6 +23,8 @@ import java.util.concurrent.Executor;
 public class ElasticSearchConnection implements Connection {
 
     private Client client;
+    //关闭标识
+    private boolean closeStatus = true;
 
     public ElasticSearchConnection(String jdbcUrl, Properties info) {
 
@@ -41,6 +43,7 @@ public class ElasticSearchConnection implements Connection {
                 transportClient.addTransportAddress(new TransportAddress(InetAddress.getByName(host), Integer.parseInt(port)));
             }
             client = transportClient;
+            closeStatus = false;
         } catch (UnknownHostException e) {
             e.printStackTrace();
         }
@@ -586,12 +589,14 @@ public class ElasticSearchConnection implements Connection {
 
     @Override
     public void close() throws SQLException {
+        this.getClient().close();
+        closeStatus = true;
 
     }
 
     @Override
     public boolean isClosed() throws SQLException {
-        return false;
+        return closeStatus;
     }
 
     @Override


### PR DESCRIPTION
修复bug 由于ElasticSearchConnection 中的close方法没有实现，导致在使用druid连接池时，elastic的tcp连接一直增加导致服务器资源占满。