### PR TITLE
修复嵌套函数中使用cast函数时script中无返回值和引用参数错误问题

### DIFF
--- a/src/main/java/org/nlpcn/es4sql/parse/CastParser.java
+++ b/src/main/java/org/nlpcn/es4sql/parse/CastParser.java
@@ -22,18 +22,24 @@ public class CastParser {
     private String alias;
     private String tableAlias;
 
+    private String name;
+
     public CastParser(SQLCastExpr castExpr, String alias, String tableAlias) {
         this.castExpr = castExpr;
         this.alias = alias;
         this.tableAlias = tableAlias;
+        this.name = "field_"+SQLFunctions.random();
     }
 
+    public String getName(){
+        return this.name ;
+    }
     public String parse(boolean isReturn) throws SqlParseException {
         List<String> result = new ArrayList<>();
 
         String dataType = castExpr.getDataType().getName().toUpperCase();
         String fileName = String.format("doc['%s'].value",Util.expr2Object(castExpr.getExpr()));
-        String name = "field_"+SQLFunctions.random();
+
 
         try {
             if (DataType.valueOf(dataType) == DataType.INT) {
@@ -53,6 +59,8 @@ public class CastParser {
             }
             if(isReturn) {
                 result.add("return " + name);
+            }else{
+                result.add(name);
             }
 
             return Joiner.on("; ").join(result);

--- a/src/main/java/org/nlpcn/es4sql/parse/FieldMaker.java
+++ b/src/main/java/org/nlpcn/es4sql/parse/FieldMaker.java
@@ -262,8 +262,9 @@ public class FieldMaker {
                 String scriptCode = new CaseWhenParser((SQLCaseExpr) object, alias, tableAlias).parse();
                 paramers.add(new KVValue("script",new SQLCharExpr(scriptCode)));
             } else if(object instanceof SQLCastExpr) {
-                String scriptCode = new CastParser((SQLCastExpr) object, alias, tableAlias).parse(false);
-                paramers.add(new KVValue("script",new SQLCharExpr(scriptCode)));
+                CastParser castParser = new CastParser((SQLCastExpr) object, alias, tableAlias);
+                String scriptCode = castParser.parse(false);
+                paramers.add(new KVValue(castParser.getName(),new SQLCharExpr(scriptCode)));
             } else {
                 paramers.add(new KVValue(Util.removeTableAilasFromField(object, tableAlias)));
             }


### PR DESCRIPTION
> select sum(cast(var as int)) as abc  from table 


after translated ， only define statement in script， need return value
```
"aggregations": {
    "abc": {
        "sum": {
            "script": {
                "source": "def field_249925342 = Double.parseDouble(doc['var'].value.toString()).intValue()",
                "lang": "painless"
            }
        }
    }
}
```

> select floor(cast(var as int)) as abc  from table 


after translated，the variable **script** referred in floor statement is wrong！

```
"script_fields": {
    "abc": {
        "script": {
            "source": "def field_454654296 = Double.parseDouble(doc['var'].value.toString()).intValue();def floor_936859053 = Math.floor(script);return floor_936859053;",
            "lang": "painless"
        },
        "ignore_failure": false
    }
}

```
