### PR TITLE
对elastic6.1.1分支做了若干的功能扩展

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ src/_site/vendor/codemirror/mode/jinja2/.goutputstream-*
 src/_site/node_modules
 src/site-server/node_modules
 *~
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   # update to java 8
   - sudo update-java-alternatives -s java-8-oracle
   - export JAVA_HOME=/usr/lib/jvm/java-8-oracle
-  - wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.4.deb && sudo dpkg -i --force-confnew elasticsearch-6.2.4.deb
+  - wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.1.1.deb && sudo dpkg -i --force-confnew elasticsearch-6.1.1.deb
   - sudo cp ./src/test/resources/elasticsearch.yml /etc/elasticsearch/elasticsearch.yml
   - sudo cat /etc/elasticsearch/elasticsearch.yml
   - sudo java -version

--- a/README.md
+++ b/README.md
@@ -54,24 +54,10 @@ Elasticsearch-SQL
 <br/>
 **5.6.4** [![5.6.4 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic5.6.4)](https://travis-ci.org/NLPchina/elasticsearch-sql)
 **5.6.5** [![5.6.5 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic5.6.5)](https://travis-ci.org/NLPchina/elasticsearch-sql)
-**5.6.6** [![5.6.6 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic5.6.6)](https://travis-ci.org/NLPchina/elasticsearch-sql)
-**5.6.7** [![5.6.7 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic5.6.7)](https://travis-ci.org/NLPchina/elasticsearch-sql)
-**5.6.8** [![5.6.8 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic5.6.8)](https://travis-ci.org/NLPchina/elasticsearch-sql)
-**5.6.9** [![5.6.9 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic5.6.9)](https://travis-ci.org/NLPchina/elasticsearch-sql)
-<br/>
 **6.0.0** [![6.0.0 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic6.0.0)](https://travis-ci.org/NLPchina/elasticsearch-sql)
 **6.0.1** [![6.0.1 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic6.0.1)](https://travis-ci.org/NLPchina/elasticsearch-sql)
 **6.1.0** [![6.1.0 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic6.1.0)](https://travis-ci.org/NLPchina/elasticsearch-sql)
 **6.1.1** [![6.1.1 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic6.1.1)](https://travis-ci.org/NLPchina/elasticsearch-sql)
-**6.1.2** [![6.1.2 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic6.1.2)](https://travis-ci.org/NLPchina/elasticsearch-sql)
-**6.1.3** [![6.1.3 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic6.1.3)](https://travis-ci.org/NLPchina/elasticsearch-sql)
-<br/>
-**6.1.4** [![6.1.4 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic6.1.4)](https://travis-ci.org/NLPchina/elasticsearch-sql)
-**6.2.0** [![6.2.0 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic6.2.0)](https://travis-ci.org/NLPchina/elasticsearch-sql)
-**6.2.1** [![6.2.1 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic6.2.1)](https://travis-ci.org/NLPchina/elasticsearch-sql)
-**6.2.2** [![6.2.2 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic6.2.2)](https://travis-ci.org/NLPchina/elasticsearch-sql)
-**6.2.3** [![6.2.3 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic6.2.3)](https://travis-ci.org/NLPchina/elasticsearch-sql)
-**6.2.4** [![6.2.4 Build Status](https://travis-ci.org/NLPchina/elasticsearch-sql.svg?branch=elastic6.2.4)](https://travis-ci.org/NLPchina/elasticsearch-sql)
 
 Query elasticsearch using familiar SQL syntax.
 You can also use ES functions in SQL.
@@ -80,7 +66,7 @@ You can also use ES functions in SQL.
 
 ## explain example 
 
-you can visite : [http://essql.nlpcn.org/](http://essql.nlpcn.org/) , it is a sample example for explain
+you can visite : [http://www.nlpcn.org:9999/web/](http://www.nlpcn.org:9999/web/) , it is a sample example for explain
 
 ## Web frontend overview
 
@@ -139,22 +125,10 @@ Versions
 | 5.6.3                 | 5.6.3.0        | delete commands not supported  | elastic5.6.3 |
 | 5.6.4                 | 5.6.4.0        | delete commands not supported  | elastic5.6.4 |
 | 5.6.5                 | 5.6.5.0        | delete commands not supported  | elastic5.6.5 |
-| 5.6.6                 | 5.6.6.0        |                                | elastic5.6.6 |
-| 5.6.7                 | 5.6.7.0        |                                | elastic5.6.7 |
-| 5.6.8                 | 5.6.8.0        |                                | elastic5.6.8 |
-| 5.6.9                 | 5.6.9.0        |                                | elastic5.6.9 |
 | 6.0.0                 | 6.0.0.0        |                                | elastic6.0.0 |
 | 6.0.1                 | 6.0.1.0        |                                | elastic6.0.1 |
 | 6.1.0                 | 6.1.0.0        |                                | elastic6.1.0 |
 | 6.1.1                 | 6.1.1.0        |                                | elastic6.1.1 |
-| 6.1.2                 | 6.1.2.0        |                                | elastic6.1.2 |
-| 6.1.3                 | 6.1.3.0        |                                | elastic6.1.3 |
-| 6.1.4                 | 6.1.4.0        |                                | elastic6.1.4 |
-| 6.2.0                 | 6.2.0.0        |                                | elastic6.2.0 |
-| 6.2.1                 | 6.2.1.0        |                                | elastic6.2.1 |
-| 6.2.2                 | 6.2.2.0        |                                | elastic6.2.2 |
-| 6.2.3                 | 6.2.3.0        |                                | elastic6.2.3 |
-| 6.2.4                 | 6.2.4.0        |                                | elastic6.2.4 |
 
 ### Elasticsearch 1.x
 ````
@@ -359,26 +333,6 @@ Versions
 ./bin/elasticsearch-plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/5.6.5.0/elasticsearch-sql-5.6.5.0.zip
 ````
 
-### Elasticsearch 5.6.6
-````
-./bin/elasticsearch-plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/5.6.6.0/elasticsearch-sql-5.6.6.0.zip
-````
-
-### Elasticsearch 5.6.7
-````
-./bin/elasticsearch-plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/5.6.7.0/elasticsearch-sql-5.6.7.0.zip
-````
-
-### Elasticsearch 5.6.8
-````
-./bin/elasticsearch-plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/5.6.8.0/elasticsearch-sql-5.6.8.0.zip
-````
-
-### Elasticsearch 5.6.9
-````
-./bin/elasticsearch-plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/5.6.9.0/elasticsearch-sql-5.6.9.0.zip
-````
-
 ### Elasticsearch 6.0.0
 ````
 ./bin/elasticsearch-plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/6.0.0.0/elasticsearch-sql-6.0.0.0.zip
@@ -397,46 +351,6 @@ Versions
 ### Elasticsearch 6.1.1
 ````
 ./bin/elasticsearch-plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/6.1.1.0/elasticsearch-sql-6.1.1.0.zip
-````
-
-### Elasticsearch 6.1.2
-````
-./bin/elasticsearch-plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/6.1.2.0/elasticsearch-sql-6.1.2.0.zip
-````
-
-### Elasticsearch 6.1.3
-````
-./bin/elasticsearch-plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/6.1.3.0/elasticsearch-sql-6.1.3.0.zip
-````
-
-### Elasticsearch 6.1.4
-````
-./bin/elasticsearch-plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/6.1.4.0/elasticsearch-sql-6.1.4.0.zip
-````
-
-### Elasticsearch 6.2.0
-````
-./bin/elasticsearch-plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/6.2.0.0/elasticsearch-sql-6.2.0.0.zip
-````
-
-### Elasticsearch 6.2.1
-````
-./bin/elasticsearch-plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/6.2.1.0/elasticsearch-sql-6.2.1.0.zip
-````
-
-### Elasticsearch 6.2.2
-````
-./bin/elasticsearch-plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/6.2.2.0/elasticsearch-sql-6.2.2.0.zip
-````
-
-### Elasticsearch 6.2.3
-````
-./bin/elasticsearch-plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/6.2.3.0/elasticsearch-sql-6.2.3.0.zip
-````
-
-### Elasticsearch 6.2.4
-````
-./bin/elasticsearch-plugin install https://github.com/NLPchina/elasticsearch-sql/releases/download/6.2.4.0/elasticsearch-sql-6.2.4.0.zip
 ````
 
 After doing this, you need to restart the Elasticsearch server. Otherwise you may get errors like `Invalid index name [sql], must not start with '']; ","status":400}`.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.nlpcn</groupId>
 	<artifactId>elasticsearch-sql</artifactId>
-	<version>6.2.4.1</version>
+	<version>6.1.1.5</version>
 	<packaging>jar</packaging>
 	<description>Query elasticsearch using SQL</description>
 	<name>elasticsearch-sql</name>
@@ -45,7 +45,9 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<runSuite>**/MainTestSuite.class</runSuite>
 		<elasticsearch.plugin.name>sql</elasticsearch.plugin.name>
-		<elasticsearch.version>6.2.4</elasticsearch.version>
+		<elasticsearch.plugin.site>true</elasticsearch.plugin.site>
+		<elasticsearch.plugin.jvm>true</elasticsearch.plugin.jvm>
+		<elasticsearch.version>6.1.1</elasticsearch.version>
 		<elasticsearch.plugin.classname>org.elasticsearch.plugin.nlpcn.SqlPlug</elasticsearch.plugin.classname>
 	</properties>
 

--- a/src/_site/controllers.js
+++ b/src/_site/controllers.js
@@ -129,7 +129,7 @@ $scope.fetchAll = function(){
         })
         .error(function(data, status, headers, config) {
           if(data == "") {
-            $scope.error = "Error occured! response is not avalible.";
+            $scope.error = "Error occured! response is not available.";
     	  }
     	  else {
     	  	$scope.error = JSON.stringify(data);
@@ -180,6 +180,7 @@ function updateWithScrollIfNeeded (query) {
     if(selectedQuery != "" && selectedQuery != undefined){
       query = selectedQuery;
     }
+
     query = updateWithScrollIfNeeded(query);
 		$http.post($scope.url + "_sql", query)
 		.success(function(data, status, headers, config) {
@@ -217,7 +218,7 @@ function updateWithScrollIfNeeded (query) {
         })
         .error(function(data, status, headers, config) {
           if(data == "") {
-            $scope.error = "Error occured! response is not avalible.";
+            $scope.error = "Error occured! response is not available.";
     	  }
     	  else {
     	  	$scope.error = JSON.stringify(data);
@@ -256,7 +257,7 @@ function updateWithScrollIfNeeded (query) {
         .error(function(data, status, headers, config) {
         	$scope.resultExplan = false;
           if(data == "") {
-            $scope.error = "Error occured! response is not avalible.";
+            $scope.error = "Error occured! response is not available.";
     	  }
     	  else {
     	  	$scope.error = JSON.stringify(data);
@@ -350,7 +351,7 @@ function updateWithScrollIfNeeded (query) {
         })
         .error(function(data, status, headers, config) {
           if(data == "") {
-            $scope.error = "Error occured! response is not avalible.";
+            $scope.error = "Error occured! response is not available.";
         }
         else {
           $scope.error = JSON.stringify(data);

--- a/src/_site/query.js
+++ b/src/_site/query.js
@@ -222,12 +222,12 @@ var AggregationQueryResultHandler = function(data) {
             }
         }
 
-        else {
+        else { //zhongshu-comment 没有子bucket了，就是最里面的那一层了
             var obj = $.extend({}, additionalColumns)
             if(bucketName != undefined) {
                 if(bucketName != undefined) {
                     if("key_as_string" in bucket){
-                        obj[bucketName] = bucket["key_as_string"]
+                        obj[bucketName] = bucket["key_as_string"] //zhongshu-comment 给字段取别名
                     }
                     else {
                         obj[bucketName] = bucket.key
@@ -238,7 +238,7 @@ var AggregationQueryResultHandler = function(data) {
             for(var field in bucket) {
 
                 var bucketValue = bucket[field]
-                if(bucketValue.buckets != undefined ){
+                if(bucketValue.buckets != undefined ){ //zhongshu-comment 如果还有子bucket的话，那就继续递归
                     var newRows = getRows(subBucketName, bucketValue, newAdditionalColumns);
                     $.merge(rows, newRows);
                     continue;
@@ -272,7 +272,7 @@ var AggregationQueryResultHandler = function(data) {
         return rows
     }
 
-
+    //zhongshu-comment 递归
     function fillFieldsForSpecificAggregation(obj,value,field)
     {   
 
@@ -287,6 +287,7 @@ var AggregationQueryResultHandler = function(data) {
         return;
     }
 
+    //zhongshu-comment 递归
     function getSubBuckets(bucket) {
         var subBuckets = [];
         for(var field in bucket) {
@@ -297,7 +298,7 @@ var AggregationQueryResultHandler = function(data) {
                 }
             }
             else {
-                innerAgg = bucket[field];
+                innerAgg = bucket[field]; //zhongshu-comment innerAgg这个变量是哪来的，貌似没声明，到时问问松哥
                 for(var innerField in innerAgg){
                     if(typeof(innerAgg[innerField])=="object"){
                         innerBuckets = getSubBuckets(innerAgg[innerField]);
@@ -312,7 +313,7 @@ var AggregationQueryResultHandler = function(data) {
 
 
     this.data = data
-    this.flattenBuckets = getRows(undefined, data.aggregations, {})
+    this.flattenBuckets = getRows(undefined, data.aggregations, {}) //zhongshu-comment 入口
 };
 
 AggregationQueryResultHandler.prototype.getHead = function() {

--- a/src/main/java/com/sohu/SqlUtil.java
+++ b/src/main/java/com/sohu/SqlUtil.java
@@ -1,0 +1,47 @@
+package com.sohu;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.statement.SQLSelectGroupByClause;
+import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
+import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlSelectQueryBlock;
+import com.alibaba.druid.sql.dialect.mysql.parser.MySqlStatementParser;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+
+import java.util.List;
+
+/**
+ * @author zhongshu
+ * @since 2018/6/29 下午4:43
+ */
+public class SqlUtil {
+
+    public static MySqlSelectQueryBlock parseSqlStrToObj(String sql) {
+        SQLStatementParser parser = new MySqlStatementParser(sql);// 直接指定使用MySQL Parser，以后遇到其他数据库的sql再扩展吧
+        SQLStatement statement = parser.parseStatement(); // 使用Parser解析生成AST，这里SQLStatement statement就是AST
+        MySqlSelectQueryBlock sqlSelectQueryBlock = (MySqlSelectQueryBlock) ((SQLSelectStatement) statement).getSelect().getQuery();
+        return sqlSelectQueryBlock;
+    }
+
+    public static int getGroupByFieldCount(String sql) {
+        try {
+            MySqlSelectQueryBlock sqlSelectQueryBlock = parseSqlStrToObj(sql);
+
+            SQLSelectGroupByClause groupByClause = sqlSelectQueryBlock.getGroupBy();
+            if (groupByClause != null){
+                List<SQLExpr> list = groupByClause.getItems();
+                return list.size();
+            } else {
+                return 0;
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            return 0;
+        }
+    }
+
+    public static void main(String[] args) {
+        String sql = "select a,b,c from tbl group by a,b,c";
+        System.out.println(getGroupByFieldCount(sql));;
+    }
+}

--- a/src/main/java/org/elasticsearch/plugin/nlpcn/RestSqlAction.java
+++ b/src/main/java/org/elasticsearch/plugin/nlpcn/RestSqlAction.java
@@ -47,10 +47,11 @@ public class RestSqlAction extends BaseRestHandler {
             sql = request.content().utf8ToString();
         }
         try {
-            int groupByFieldCount = SqlUtil.getGroupByFieldCount(sql);
-            if (groupByFieldCount > 7) {
-                throw new Exception("group by field count can not large than 7");
-            }
+            //zhongshu-comment 放开这个限制
+            //            int groupByFieldCount = SqlUtil.getGroupByFieldCount(sql);
+//            if (groupByFieldCount > 7) {
+//                throw new Exception("group by field count can not large than 7");
+//            }
 
             SearchDao searchDao = new SearchDao(client);
             QueryAction queryAction = null;

--- a/src/main/java/org/elasticsearch/plugin/nlpcn/RestSqlAction.java
+++ b/src/main/java/org/elasticsearch/plugin/nlpcn/RestSqlAction.java
@@ -1,5 +1,12 @@
 package org.elasticsearch.plugin.nlpcn;
 
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
+import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlSelectQueryBlock;
+import com.alibaba.druid.sql.dialect.mysql.parser.MySqlStatementParser;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import com.sohu.SqlUtil;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugin.nlpcn.executors.ActionRequestRestExecuterFactory;
@@ -40,6 +47,11 @@ public class RestSqlAction extends BaseRestHandler {
             sql = request.content().utf8ToString();
         }
         try {
+            int groupByFieldCount = SqlUtil.getGroupByFieldCount(sql);
+            if (groupByFieldCount > 7) {
+                throw new Exception("group by field count can not large than 7");
+            }
+
             SearchDao searchDao = new SearchDao(client);
             QueryAction queryAction = null;
 
@@ -70,6 +82,8 @@ public class RestSqlAction extends BaseRestHandler {
                 return channel -> restExecutor.execute(client, additionalParams, finalQueryAction, channel);
             }
         } catch (SqlParseException | SQLFeatureNotSupportedException e) {
+            e.printStackTrace();
+        } catch (Exception e) {
             e.printStackTrace();
         }
         return null;

--- a/src/main/java/org/elasticsearch/plugin/nlpcn/executors/CSVResultsExtractor.java
+++ b/src/main/java/org/elasticsearch/plugin/nlpcn/executors/CSVResultsExtractor.java
@@ -156,8 +156,7 @@ public class CSVResultsExtractor {
             if(!header.contains(name)){
                 header.add(name);
             }
-            NumericMetricsAggregation.SingleValue agg = (NumericMetricsAggregation.SingleValue) aggregation;
-            line.add(!Double.isInfinite(agg.value()) ? agg.getValueAsString() : "null");
+            line.add(((NumericMetricsAggregation.SingleValue) aggregation).getValueAsString());
         }
         //todo:Numeric MultiValue - Stats,ExtendedStats,Percentile...
         else if(aggregation instanceof NumericMetricsAggregation.MultiValue){

--- a/src/main/java/org/nlpcn/es4sql/SQLFunctions.java
+++ b/src/main/java/org/nlpcn/es4sql/SQLFunctions.java
@@ -62,6 +62,12 @@ public class SQLFunctions {
 
             case "floor":
             case "round":
+                if (paramers.size() == 2) {
+                    //zhongshu-comment es的round()默认是保留到个位，这里给round()函数加上精确到小数点后第几位的功能
+                    int decimalPrecision = Integer.parseInt(paramers.get(1).value.toString());
+                    functionStr = mathRoundTemplate("Math."+methodName,methodName,Util.expr2Object((SQLExpr) paramers.get(0).value).toString(), name, decimalPrecision);
+                    break;
+                }
             case "log":
             case "log10":
             case "ceil":
@@ -277,6 +283,23 @@ public class SQLFunctions {
             return new Tuple<>(name, "def " + name + " = " + methodName + "(doc['" + strColumn + "'].value)");
         } else {
             return new Tuple<>(name, strColumn + ";def " + name + " = " + methodName + "(" + valueName + ")");
+        }
+
+    }
+
+    private static Tuple<String, String> mathRoundTemplate(String methodName, String fieldName, String strColumn, String valueName, int decimalPrecision) {
+
+        StringBuilder sb = new StringBuilder("1");
+        for (int i = 0; i < decimalPrecision; i++) {
+            sb.append("0");
+        }
+        double num = Double.parseDouble(sb.toString());
+
+        String name = fieldName + "_" + random();
+        if (valueName == null) {
+            return new Tuple<>(name, "def " + name + " = " + methodName + "((doc['" + strColumn + "'].value) * " + num + ")/" + num);
+        } else {
+            return new Tuple<>(name, strColumn + ";def " + name + " = " + methodName + "((" + valueName + ") * " + num + ")/" + num);
         }
 
     }

--- a/src/main/java/org/nlpcn/es4sql/SQLFunctions.java
+++ b/src/main/java/org/nlpcn/es4sql/SQLFunctions.java
@@ -29,7 +29,7 @@ public class SQLFunctions {
 
     public static Tuple<String, String> function(String methodName, List<KVValue> paramers, String name,boolean returnValue) {
         Tuple<String, String> functionStr = null;
-        switch (methodName) {
+        switch (methodName.toLowerCase()) {
             case "if":
                 String nameIF = "";
                 String caseString = "";

--- a/src/main/java/org/nlpcn/es4sql/SQLFunctions.java
+++ b/src/main/java/org/nlpcn/es4sql/SQLFunctions.java
@@ -57,7 +57,6 @@ public class SQLFunctions {
                 functionStr = date_format(
                         Util.expr2Object((SQLExpr) paramers.get(0).value).toString(),
                         Util.expr2Object((SQLExpr) paramers.get(1).value).toString(),
-                        2 < paramers.size() ? Util.expr2Object((SQLExpr) paramers.get(2).value).toString() : null,
                         name);
                 break;
 
@@ -156,12 +155,10 @@ public class SQLFunctions {
         return new Tuple<>(name, script);
     }
 
-    private static Tuple<String, String> date_format(String strColumn, String pattern, String zoneId, String valueName) {
+    private static Tuple<String, String> date_format(String strColumn, String pattern, String valueName) {
         String name = "date_format_" + random();
         if (valueName == null) {
-            return new Tuple<>(name, "def " + name + " = DateTimeFormatter.ofPattern('" + pattern + "').withZone(" +
-                    (zoneId != null ? "ZoneId.of('" + zoneId + "')" : "ZoneId.systemDefault()") +
-                    ").format(Instant.ofEpochMilli(doc['" + strColumn + "'].value.getMillis()))");
+            return new Tuple<>(name, "def " + name + " = new SimpleDateFormat('" + pattern + "').format(new Date(doc['" + strColumn + "'].value - 8*1000*60*60))");
         } else {
             return new Tuple<>(name, strColumn + "; def " + name + " = new SimpleDateFormat('" + pattern + "').format(new Date(" + valueName + " - 8*1000*60*60))");
         }
@@ -221,7 +218,7 @@ public class SQLFunctions {
         String newScript = variance[variance.length - 1];
         if (newScript.trim().startsWith("def ")) {
             //for now ,if variant is string,then change to double.
-            return newScript.trim().substring(4).split("=")[0].trim();
+            return newScript.substring(4).split("=")[0].trim();
         } else return scriptStr;
     }
 
@@ -232,7 +229,7 @@ public class SQLFunctions {
         String newScript = variance[variance.length - 1];
         if (newScript.trim().startsWith("def ")) {
             //for now ,if variant is string,then change to double.
-            String temp = newScript.trim().substring(4).split("=")[0].trim();
+            String temp = newScript.substring(4).split("=")[0].trim();
 
             return " if( " + temp + " instanceof String) " + temp + "= Double.parseDouble(" + temp.trim() + "); ";
         } else return "";

--- a/src/main/java/org/nlpcn/es4sql/Util.java
+++ b/src/main/java/org/nlpcn/es4sql/Util.java
@@ -100,8 +100,14 @@ public class Util {
             return ((SQLNumericLiteralExpr) expr).getNumber();
         } else if (expr instanceof SQLNullExpr) {
             return ((SQLNullExpr) expr).toString().toLowerCase();
+        } else if (expr instanceof  SQLBinaryOpExpr) {
+            //zhongshu-comment 该分支由忠树添加
+            String left = "doc['" + ((SQLBinaryOpExpr) expr).getLeft().toString() + "'].value";
+            String operator = ((SQLBinaryOpExpr) expr).getOperator().getName();
+            String right = "doc['" + ((SQLBinaryOpExpr) expr).getRight().toString() + "'].value";
+            return left + operator + right;
         }
-        throw new SqlParseException("could not parse sqlBinaryOpExpr need to be identifier/valuable got" + expr.getClass().toString() + " with value:" + expr.toString());
+        throw new SqlParseException("could not parse sqlBinaryOpExpr need to be identifier/valuable got " + expr.getClass().toString() + " with value:" + expr.toString());
     }
 
     public static boolean isFromJoinOrUnionTable(SQLExpr expr) {

--- a/src/main/java/org/nlpcn/es4sql/Util.java
+++ b/src/main/java/org/nlpcn/es4sql/Util.java
@@ -138,7 +138,7 @@ public class Util {
         double[] ds = new double[params.size()];
         int i = 0;
         for (KVValue v : params) {
-            ds[i] = Double.parseDouble(v.value.toString());
+            ds[i] = ((Number) v.value).doubleValue();
             i++;
         }
         return ds;

--- a/src/main/java/org/nlpcn/es4sql/domain/Condition.java
+++ b/src/main/java/org/nlpcn/es4sql/domain/Condition.java
@@ -88,6 +88,10 @@ public class Condition extends Where {
     private boolean isChildren;
     private String childType;
 
+    public Condition(CONN conn) {
+        super(conn);
+    }
+
     public Condition(CONN conn, String field, SQLExpr nameExpr, String condition, Object obj, SQLExpr valueExpr) throws SqlParseException {
         this(conn, field, nameExpr, condition, obj, valueExpr, null);
     }

--- a/src/main/java/org/nlpcn/es4sql/domain/From.java
+++ b/src/main/java/org/nlpcn/es4sql/domain/From.java
@@ -16,17 +16,6 @@ public class From {
 	 * @param from The part after the FROM keyword.
 	 */
 	public From(String from) {
-		if (from.startsWith("<")) {
-			index = from;
-			if (!from.endsWith(">")) {
-				int i = from.lastIndexOf('/');
-				if (-1 < i) {
-					index = from.substring(0, i);
-					type = from.substring(i + 1);
-				}
-			}
-			return;
-		}
 		String[] parts = from.split("/");
 		this.index = parts[0].trim();
 		if (parts.length == 2) {

--- a/src/main/java/org/nlpcn/es4sql/domain/Order.java
+++ b/src/main/java/org/nlpcn/es4sql/domain/Order.java
@@ -1,5 +1,7 @@
 package org.nlpcn.es4sql.domain;
 
+import org.elasticsearch.search.sort.ScriptSortBuilder;
+
 /**
  * 排序规则
  * @author ansj
@@ -9,6 +11,7 @@ public class Order {
 	private String nestedPath;
 	private String name;
 	private String type;
+	private ScriptSortBuilder.ScriptSortType scriptSortType;
 
 	public Order(String nestedPath, String name, String type) {
         this.nestedPath = nestedPath;
@@ -40,4 +43,11 @@ public class Order {
 		this.type = type;
 	}
 
+	public ScriptSortBuilder.ScriptSortType getScriptSortType() {
+		return scriptSortType;
+	}
+
+	public void setScriptSortType(ScriptSortBuilder.ScriptSortType scriptSortType) {
+		this.scriptSortType = scriptSortType;
+	}
 }

--- a/src/main/java/org/nlpcn/es4sql/domain/Paramer.java
+++ b/src/main/java/org/nlpcn/es4sql/domain/Paramer.java
@@ -23,10 +23,6 @@ public class Paramer {
 	public String value;
     public Integer slop;
 
-    public Map<String, Float> fieldsBoosts = new HashMap<>();
-    public String type;
-    public Float tieBreaker;
-    public Operator operator;
 
 	public static Paramer parseParamer(SQLMethodInvokeExpr method) throws SqlParseException {
 		Paramer instance = new Paramer();
@@ -56,26 +52,6 @@ public class Paramer {
                         instance.slop = Integer.parseInt(Util.expr2Object(sqlExpr.getRight()).toString());
                         break;
 
-                    case "fields":
-                        int index;
-                        for (String f : Strings.split(Util.expr2Object(sqlExpr.getRight()).toString(), ",")) {
-                            index = f.lastIndexOf('^');
-                            if (-1 < index) {
-                                instance.fieldsBoosts.put(f.substring(0, index), Float.parseFloat(f.substring(index + 1)));
-                            } else {
-                                instance.fieldsBoosts.put(f, 1.0F);
-                            }
-                        }
-                        break;
-                    case "type":
-                        instance.type = Util.expr2Object(sqlExpr.getRight()).toString();
-                        break;
-                    case "tie_breaker":
-                        instance.tieBreaker = Float.parseFloat(Util.expr2Object(sqlExpr.getRight()).toString());
-                        break;
-                    case "operator":
-                        instance.operator = Operator.fromString(Util.expr2Object(sqlExpr.getRight()).toString());
-                        break;
                     default:
                         break;
                 }
@@ -132,33 +108,6 @@ public class Paramer {
             query.phraseSlop(paramer.slop);
         }
 
-        return query;
-    }
-
-    public static ToXContent fullParamer(MultiMatchQueryBuilder query, Paramer paramer) {
-        if (paramer.analysis != null) {
-            query.analyzer(paramer.analysis);
-        }
-
-        if (paramer.boost != null) {
-            query.boost(paramer.boost);
-        }
-
-        if (paramer.slop != null) {
-            query.slop(paramer.slop);
-        }
-
-        if (paramer.type != null) {
-            query.type(paramer.type);
-        }
-
-        if (paramer.tieBreaker != null) {
-            query.tieBreaker(paramer.tieBreaker);
-        }
-
-        if (paramer.operator != null) {
-            query.operator(paramer.operator);
-        }
 
         return query;
     }

--- a/src/main/java/org/nlpcn/es4sql/domain/Select.java
+++ b/src/main/java/org/nlpcn/es4sql/domain/Select.java
@@ -23,7 +23,8 @@ public class Select extends Query {
 	private List<List<Field>> groupBys = new ArrayList<>();
 	private List<Order> orderBys = new ArrayList<>();
 	private int offset;
-	private int rowCount = 1000;
+	public static final int DEFAULT_ROWCOUNT = 1000;
+	private int rowCount = DEFAULT_ROWCOUNT;
     private boolean containsSubQueries;
     private List<SubQueryExpression> subQueries;
 	public boolean isQuery = false;

--- a/src/main/java/org/nlpcn/es4sql/domain/Select.java
+++ b/src/main/java/org/nlpcn/es4sql/domain/Select.java
@@ -1,5 +1,6 @@
 package org.nlpcn.es4sql.domain;
 
+import org.elasticsearch.search.sort.ScriptSortBuilder;
 import org.nlpcn.es4sql.domain.hints.Hint;
 import org.nlpcn.es4sql.parse.SubQueryExpression;
 
@@ -22,7 +23,7 @@ public class Select extends Query {
 	private List<List<Field>> groupBys = new ArrayList<>();
 	private List<Order> orderBys = new ArrayList<>();
 	private int offset;
-	private int rowCount = 200;
+	private int rowCount = 1000;
     private boolean containsSubQueries;
     private List<SubQueryExpression> subQueries;
 	public boolean isQuery = false;
@@ -72,11 +73,14 @@ public class Select extends Query {
 		return rowCount;
 	}
 
-	public void addOrderBy(String nestedPath, String name, String type) {
+	public void addOrderBy(String nestedPath, String name, String type, ScriptSortBuilder.ScriptSortType scriptSortType) {
 		if ("_score".equals(name)) { //zhongshu-comment 可以直接在order by子句中写_score，根据该字段排序 select * from tbl order by _score asc
 			isQuery = true;
 		}
-		this.orderBys.add(new Order(nestedPath, name, type));
+		Order order = new Order(nestedPath, name, type);
+
+		order.setScriptSortType(scriptSortType);
+		this.orderBys.add(order);
 	}
 
 

--- a/src/main/java/org/nlpcn/es4sql/parse/CaseWhenParser.java
+++ b/src/main/java/org/nlpcn/es4sql/parse/CaseWhenParser.java
@@ -121,11 +121,11 @@ public class CaseWhenParser {
             throw new SqlParseException("you should assign some value in bracket!!");
 
         String script = "(";
-        String template = "doc['" + condition.getName() + "'].value " + judgeOperator + " %s " + booleanOperator;
+        String template = "doc['" + condition.getName() + "'].value " + judgeOperator + " %s " + booleanOperator + " "; //结尾这个空格就只空一格
         for (Object obj : objArr) {
             script = script + String.format(template, parseInNotInValueWithQuote(obj));
         }
-        script = script.substring(0, script.length() - booleanOperator.length());//去掉末尾的&&
+        script = script.substring(0, script.lastIndexOf(booleanOperator));//去掉末尾的&&
         script += ")"; //(doc['a'].value == 1 &&doc['a'].value == 2 &&doc['a'].value == 3 )
         codes.add(script);
     }

--- a/src/main/java/org/nlpcn/es4sql/parse/CaseWhenParser.java
+++ b/src/main/java/org/nlpcn/es4sql/parse/CaseWhenParser.java
@@ -13,6 +13,7 @@ import org.nlpcn.es4sql.domain.Where;
 import org.nlpcn.es4sql.exception.SqlParseException;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -81,13 +82,63 @@ public class CaseWhenParser {
      * @return
      * @throws SqlParseException
      */
-    public String parseCaseWhenInWhere() throws SqlParseException {
-        //todo
-        return null;
+    public String parseCaseWhenInWhere(Object[] valueArr) throws SqlParseException {
+        List<String> result = new ArrayList<String>();
+        String TMP = "tmp";
+        result.add("String " + TMP + " = '';");
+
+        for (SQLCaseExpr.Item item : caseExpr.getItems()) {
+            SQLExpr conditionExpr = item.getConditionExpr();
+
+            WhereParser parser = new WhereParser(new SqlParser(), conditionExpr);
+
+            String scriptCode = explain(parser.findWhere());
+            if (scriptCode.startsWith(" &&")) {
+                scriptCode = scriptCode.substring(3);
+            }
+            if (result.size() == 1) { //zhongshu-comment 在for循环之前就已经先add了一个元素
+                result.add("if(" + scriptCode + ")" + "{" + TMP + "=" + Util.getScriptValueWithQuote(item.getValueExpr(), "'") + "}");
+            } else {
+                result.add("else if(" + scriptCode + ")" + "{" + TMP + "=" + Util.getScriptValueWithQuote(item.getValueExpr(), "'") + "}");
+            }
+
+        }
+        SQLExpr elseExpr = caseExpr.getElseExpr();
+        if (elseExpr == null) {
+            result.add("else { null }");
+        } else {
+            result.add("else {" + TMP + "=" + Util.getScriptValueWithQuote(elseExpr, "'") + "}");
+        }
+
+        /*
+        zhongshu-comment
+        1、第一种情况in
+        field in (a, b, c)     --> field == a || field == b || field == c
+
+        2、第二种情况not in
+        field not in (a, b, c) --> field != a && field != b && field != c
+                         等价于 --> !(field == a || field == b || field == c) 即对第一种情况取反，
+                                    (field == a || field == b || field == c)里的a、b、c要全部为false，!(field == a || field == b || field == c)才为true
+
+        3、这里只拼接第一种情况，不拼接第一种情况，
+            如果要需要第二种情况，那就调用该方法得到返回值后自行拼上取反符号和括号: !(${该方法的返回值})
+         */
+        String judgeStatement = parseInNotInJudge(valueArr, TMP, "==", "||", true);
+        result.add("return " + judgeStatement +  ";");
+        return Joiner.on(" ").join(result);
     }
 
     /**
      * zhongshu-comment 这个方法应该设为private比较合适，因为只在上文的parse()方法中被调用了
+     * zhongshu-comment 将case when的各种条件判断转换为script的if-else判断，举例如下
+         case when：
+         CASE
+         WHEN platform_id = 'PC' AND os NOT IN ('全部') THEN 'unknown'
+         ELSE os
+
+         script的if-else：
+         将上文case when例子中的WHEN platform_id = 'PC' AND os NOT IN ('全部') THEN 'unknown' 解析成如下的script：
+         (doc['platform_id'].value=='PC') && (doc['os'].value != '全部' )
      * @param where
      * @return
      * @throws SqlParseException
@@ -113,12 +164,11 @@ public class CaseWhenParser {
                 Object[] objs = (Object[]) condition.getValue();
                 codes.add("(" + "doc['" + condition.getName() + "'].value >= " + objs[0] + " && doc['"
                         + condition.getName() + "'].value <=" + objs[1] + ")");
-            }
-            else if (condition.getOpear() == OPEAR.IN) {// in
+            } else if (condition.getOpear() == OPEAR.IN) {// in
                 //zhongshu-comment 增加该分支，可以解析case when判断语句中的in、not in判断语句
-                parseInNotInJudge(condition, codes, "==", "||");
+                codes.add(parseInNotInJudge(condition, "==", "||", false));
             } else if (condition.getOpear() == OPEAR.NIN) { // not in
-                parseInNotInJudge(condition, codes, "!=", "&&");
+                codes.add(parseInNotInJudge(condition, "!=", "&&", false));
             } else {
                 SQLExpr nameExpr = condition.getNameExpr();
                 SQLExpr valueExpr = condition.getValueExpr();
@@ -143,24 +193,37 @@ public class CaseWhenParser {
     /**
      * @author zhongshu
      * @param condition
-     * @param codes
      * @param judgeOperator
      * @param booleanOperator
      * @throws SqlParseException
      */
-    private void parseInNotInJudge(Condition condition, List<String> codes, String judgeOperator, String booleanOperator) throws SqlParseException {
+    private String parseInNotInJudge(Condition condition, String judgeOperator, String booleanOperator, boolean flag) throws SqlParseException {
         Object[] objArr = (Object[]) condition.getValue();
         if (objArr.length == 0)
             throw new SqlParseException("you should assign some value in bracket!!");
 
         String script = "(";
+
         String template = "doc['" + condition.getName() + "'].value " + judgeOperator + " %s " + booleanOperator + " "; //结尾这个空格就只空一格
+        if (flag) {
+            template = condition.getName() + " " + judgeOperator + " %s " + booleanOperator + " "; //结尾这个空格就只空一格;
+        }
         for (Object obj : objArr) {
             script = script + String.format(template, parseInNotInValueWithQuote(obj));
         }
         script = script.substring(0, script.lastIndexOf(booleanOperator));//去掉末尾的&&
-        script += ")"; //(doc['a'].value == 1 &&doc['a'].value == 2 &&doc['a'].value == 3 )
-        codes.add(script);
+        script += ")"; //zhongshu-comment script结果示例 (doc['a'].value == 1 && doc['a'].value == 2 && doc['a'].value == 3 )
+        return script;
+
+    }
+
+    private String parseInNotInJudge(Object value, String fieldName, String judgeOperator, String booleanOperator, boolean flag) throws SqlParseException {
+        Condition cond = new Condition(null);
+        cond.setValue(value);
+        cond.setName(fieldName);
+
+        return parseInNotInJudge(cond, judgeOperator, booleanOperator, flag);
+
     }
 
     /**

--- a/src/main/java/org/nlpcn/es4sql/parse/FieldMaker.java
+++ b/src/main/java/org/nlpcn/es4sql/parse/FieldMaker.java
@@ -289,7 +289,7 @@ public class FieldMaker {
         }
         //zhongshu-comment script字段不会走这个分支
         //just check we can find the function
-        if (SQLFunctions.buildInFunctions.contains(finalMethodName)) {
+        if (SQLFunctions.buildInFunctions.contains(finalMethodName.toLowerCase())) {
             if (alias == null && first) {
                 alias = "field_" + SQLFunctions.random();//paramers.get(0).value.toString();
             }
@@ -301,7 +301,12 @@ public class FieldMaker {
                 //variance
                 paramers.add(new KVValue(newFunctions.v1()));
             } else {
-                paramers.add(new KVValue(alias));
+                
+                if(newFunctions.v1().toLowerCase().contains("if")){
+                    paramers.add(new KVValue(newFunctions.v1()));
+                }else {
+                    paramers.add(new KVValue(alias));
+                }
             }
 
             paramers.add(new KVValue(newFunctions.v2()));

--- a/src/main/java/org/nlpcn/es4sql/parse/FieldMaker.java
+++ b/src/main/java/org/nlpcn/es4sql/parse/FieldMaker.java
@@ -58,7 +58,11 @@ public class FieldMaker {
         } else if (expr instanceof SQLCaseExpr) {
             String scriptCode = new CaseWhenParser((SQLCaseExpr) expr, alias, tableAlias).parse();
             List<KVValue> methodParameters = new ArrayList<>();
-            methodParameters.add(new KVValue(alias));
+            //zhongshu-comment group by子句中case when是没有别名的，这时alias=null，调用KVValue的toString()会报空指针
+//            methodParameters.add(new KVValue(alias)); //zhongshu-comment 这是原语句，被我注释掉了，改为下面带非空判断的语句
+            if (null != alias && alias.trim().length() != 0) {
+                methodParameters.add(new KVValue(alias));
+            }
             methodParameters.add(new KVValue(scriptCode));
             return new MethodField("script", methodParameters, null, alias);
         }else if (expr instanceof SQLCastExpr) {

--- a/src/main/java/org/nlpcn/es4sql/parse/FieldMaker.java
+++ b/src/main/java/org/nlpcn/es4sql/parse/FieldMaker.java
@@ -59,8 +59,8 @@ public class FieldMaker {
             //zhongshu-comment case when走这个分支
             String scriptCode = new CaseWhenParser((SQLCaseExpr) expr, alias, tableAlias).parse();
             List<KVValue> methodParameters = new ArrayList<>();
-            //zhongshu-comment group by子句中case when是没有别名的，这时alias=null，调用KVValue的toString()会报空指针
-//            methodParameters.add(new KVValue(alias)); //zhongshu-comment 这是原语句，被我注释掉了，改为下面带非空判断的语句
+            /*zhongshu-comment group by子句中case when是没有别名的，这时alias=null，调用KVValue的toString()会报空指针
+            methodParameters.add(new KVValue(alias)); //zhongshu-comment 这是原语句，被我注释掉了，改为下面带非空判断的语句*/
             if (null != alias && alias.trim().length() != 0) {
                 methodParameters.add(new KVValue(alias));
             }

--- a/src/main/java/org/nlpcn/es4sql/parse/SqlParser.java
+++ b/src/main/java/org/nlpcn/es4sql/parse/SqlParser.java
@@ -47,13 +47,14 @@ public class SqlParser {
     public Select parseSelect(MySqlSelectQueryBlock query) throws SqlParseException {
 
         Select select = new Select();
-        //zhongshu-comment SqlParser类没有成员变量，里面全是方法，所以将this传到WhereParser对象时是无状态的，
-        //                  即SqlParser对象并没有给WhereParser传递任何属性，也不存在WhereParser修改SqlParser的成员变量值这一说
-        //                 WhereParser只是单纯想调用SqlParser的方法而已
+        /*zhongshu-comment SqlParser类没有成员变量，里面全是方法，所以将this传到WhereParser对象时是无状态的，
+                          即SqlParser对象并没有给WhereParser传递任何属性，也不存在WhereParser修改SqlParser的成员变量值这一说
+                         WhereParser只是单纯想调用SqlParser的方法而已
+        */
         WhereParser whereParser = new WhereParser(this, query);
 
         /*
-        zhongshu-comment 例如sql：select   a,sum(b),case when c='a' then 1 else 2 end as my_c   from tbl，
+        zhongshu-comment 例如sql：select   a,sum(b),case when c='a' then 1 else 2 end as my_c from tbl，
         那findSelect()就是解析这一部分了：a,sum(b),case when c='a' then 1 else 2 end as my_c
          */
         findSelect(query, select, query.getFrom().getAlias()); //zhongshu-comment 看过

--- a/src/main/java/org/nlpcn/es4sql/parse/WhereParser.java
+++ b/src/main/java/org/nlpcn/es4sql/parse/WhereParser.java
@@ -405,6 +405,13 @@ public class WhereParser {
 
                 where.addWhere(condition);
             } else if (methodName.toLowerCase().equals("script")) {
+                /*
+                zhongshu-comment 这里也是Script Query，但是貌似没见过有走这个分支的sql
+                1、文档
+                    https://www.elastic.co/guide/en/elasticsearch/reference/6.1/query-dsl-script-query.html
+                2、java api
+                    https://www.elastic.co/guide/en/elasticsearch/client/java-api/6.1/java-specialized-queries.html
+                 */
                 ScriptFilter scriptFilter = new ScriptFilter();
                 if (!scriptFilter.tryParseFromMethodExpr(methodExpr)) {
                     throw new SqlParseException("could not parse script filter");

--- a/src/main/java/org/nlpcn/es4sql/parse/WhereParser.java
+++ b/src/main/java/org/nlpcn/es4sql/parse/WhereParser.java
@@ -1,24 +1,10 @@
 package org.nlpcn.es4sql.parse;
 
+import com.alibaba.druid.sql.ast.expr.*;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 import com.alibaba.druid.sql.ast.SQLExpr;
-import com.alibaba.druid.sql.ast.expr.SQLBetweenExpr;
-import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
-import com.alibaba.druid.sql.ast.expr.SQLBinaryOperator;
-import com.alibaba.druid.sql.ast.expr.SQLCharExpr;
-import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
-import com.alibaba.druid.sql.ast.expr.SQLInListExpr;
-import com.alibaba.druid.sql.ast.expr.SQLInSubQueryExpr;
-import com.alibaba.druid.sql.ast.expr.SQLMethodInvokeExpr;
-import com.alibaba.druid.sql.ast.expr.SQLNotExpr;
-import com.alibaba.druid.sql.ast.expr.SQLNullExpr;
-import com.alibaba.druid.sql.ast.expr.SQLNumericLiteralExpr;
-import com.alibaba.druid.sql.ast.expr.SQLPropertyExpr;
-import com.alibaba.druid.sql.ast.expr.SQLQueryExpr;
-import com.alibaba.druid.sql.ast.expr.SQLTextLiteralExpr;
-import com.alibaba.druid.sql.ast.expr.SQLVariantRefExpr;
 import com.alibaba.druid.sql.ast.statement.SQLDeleteStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlSelectQueryBlock;
 
@@ -310,9 +296,24 @@ public class WhereParser {
                 condition = new Condition(Where.CONN.valueOf(opear), leftSide, null, siExpr.isNot() ? "NOT IN" : "IN", parseValue(siExpr.getTargetList()), null, nestedType);
             else if (isChildren)
                 condition = new Condition(Where.CONN.valueOf(opear), leftSide, null, siExpr.isNot() ? "NOT IN" : "IN", parseValue(siExpr.getTargetList()), null, childrenType);
-            else
-                condition = new Condition(Where.CONN.valueOf(opear), leftSide, null, siExpr.isNot() ? "NOT IN" : "IN", parseValue(siExpr.getTargetList()), null);
+            else if (siExpr.getExpr() instanceof SQLCaseExpr) {
+                //zhongshu-comment todo 增加代码
 
+                condition = new Condition(Where.CONN.valueOf(opear),
+                        leftSide, //zhongshu-comment 这个参数传过去也没有，只是SQLCaseExpr对象的地址
+                        siExpr.getExpr(), //zhongshu-comment 这个才是有用的参数，是SQLCaseExpr对象
+                        siExpr.isNot() ? "NOT IN" : "IN",
+                        parseValue(siExpr.getTargetList()),
+                        null);
+            }
+            else {
+                condition = new Condition(Where.CONN.valueOf(opear),
+                        leftSide,
+                        null,
+                        siExpr.isNot() ? "NOT IN" : "IN",
+                        parseValue(siExpr.getTargetList()),
+                        null);
+            }
             where.addWhere(condition);
         } else if (expr instanceof SQLBetweenExpr) {
             SQLBetweenExpr between = ((SQLBetweenExpr) expr);

--- a/src/main/java/org/nlpcn/es4sql/query/AggregationQueryAction.java
+++ b/src/main/java/org/nlpcn/es4sql/query/AggregationQueryAction.java
@@ -46,7 +46,8 @@ public class AggregationQueryAction extends QueryAction {
 
     @Override
     public SqlElasticSearchRequestBuilder explain() throws SqlParseException {
-        this.request = client.prepareSearch();
+//        this.request = client.prepareSearch();//zhongshu-comment elastic6.1.1的写法
+        this.request = new SearchRequestBuilder(client, SearchAction.INSTANCE); //zhongshu-comment master的写法
 
         setIndicesAndTypes();
 

--- a/src/main/java/org/nlpcn/es4sql/query/AggregationQueryAction.java
+++ b/src/main/java/org/nlpcn/es4sql/query/AggregationQueryAction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.join.aggregations.JoinAggregationBuilders;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.BucketOrder;
+import org.elasticsearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.nested.NestedAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.nested.ReverseNestedAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
@@ -217,6 +218,9 @@ public class AggregationQueryAction extends QueryAction {
     }
 
     private void setSize (AggregationBuilder agg, Field field) {
+        if (agg instanceof HistogramAggregationBuilder)
+            return;
+
         if (field instanceof MethodField) { //zhongshu-comment MethodField可以自定义聚合的size
             MethodField mf = ((MethodField) field);
             Object customSize = mf.getParamsAsMap().get("size");
@@ -242,6 +246,9 @@ public class AggregationQueryAction extends QueryAction {
         }
     }
     private void setShardSize(AggregationBuilder agg) {
+        if (agg instanceof HistogramAggregationBuilder)
+            return;
+
         int defaultShardSize = 20 * select.getRowCount();
         if (defaultShardSize > 5000)
             ((TermsAggregationBuilder) agg).shardSize(defaultShardSize);

--- a/src/main/java/org/nlpcn/es4sql/query/AggregationQueryAction.java
+++ b/src/main/java/org/nlpcn/es4sql/query/AggregationQueryAction.java
@@ -46,7 +46,7 @@ public class AggregationQueryAction extends QueryAction {
 
     @Override
     public SqlElasticSearchRequestBuilder explain() throws SqlParseException {
-        this.request = new SearchRequestBuilder(client, SearchAction.INSTANCE);
+        this.request = client.prepareSearch();
 
         setIndicesAndTypes();
 

--- a/src/main/java/org/nlpcn/es4sql/query/AggregationQueryAction.java
+++ b/src/main/java/org/nlpcn/es4sql/query/AggregationQueryAction.java
@@ -218,7 +218,11 @@ public class AggregationQueryAction extends QueryAction {
 
     private void setSize (AggregationBuilder agg) {
         if(select.getRowCount()>0) {
-            ((TermsAggregationBuilder) agg).size(select.getRowCount());
+            try {
+                ((TermsAggregationBuilder) agg).size(select.getRowCount());
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
         }
     }
     private void setShardSize(AggregationBuilder agg) {

--- a/src/main/java/org/nlpcn/es4sql/query/DefaultQueryAction.java
+++ b/src/main/java/org/nlpcn/es4sql/query/DefaultQueryAction.java
@@ -45,7 +45,10 @@ public class DefaultQueryAction extends QueryAction {
 	//zhongshu-comment 将sql字符串解析后的java对象，转换为es的查询请求对象
 	@Override
 	public SqlElasticSearchRequestBuilder explain() throws SqlParseException {
-		this.request = client.prepareSearch();//zhongshu-comment conflict
+//		this.request = client.prepareSearch();//zhongshu-comment conflict
+		//zhongshu-comment 变量request是es搜索请求对象，调用的是es的api，SearchRequestBuilder是es的原生api
+		this.request = new SearchRequestBuilder(client, SearchAction.INSTANCE);
+
 		setIndicesAndTypes();
 
 		//zhongshu-comment 将Select对象中封装的sql token信息转换并传到成员变量es搜索请求对象request中

--- a/src/main/java/org/nlpcn/es4sql/query/DefaultQueryAction.java
+++ b/src/main/java/org/nlpcn/es4sql/query/DefaultQueryAction.java
@@ -134,7 +134,7 @@ public class DefaultQueryAction extends QueryAction {
 			ArrayList<String> excludeFields = new ArrayList<String>();
 
 			for (Field field : fields) {
-				if (field instanceof MethodField) {
+				if (field instanceof MethodField) { //zhongshu-comment MethodField是Field的子类，而且Field也就只有MethodField这一个子类了
 					MethodField method = (MethodField) field;
 					if (method.getName().toLowerCase().equals("script")) {
 						/*

--- a/src/main/java/org/nlpcn/es4sql/query/DefaultQueryAction.java
+++ b/src/main/java/org/nlpcn/es4sql/query/DefaultQueryAction.java
@@ -218,7 +218,8 @@ public class DefaultQueryAction extends QueryAction {
             } else if (order.getName().contains("script(")) { //zhongshu-comment 该分支是我后来加的，用于兼容order by case when那种情况
 				String scriptStr = order.getName().substring("script(".length(), order.getName().length() - 1);
 				Script script = new Script(scriptStr);
-				ScriptSortBuilder scriptSortBuilder = SortBuilders.scriptSort(script, ScriptSortBuilder.ScriptSortType.NUMBER);
+				ScriptSortBuilder scriptSortBuilder = SortBuilders.scriptSort(script, order.getScriptSortType());
+
 				scriptSortBuilder = scriptSortBuilder.order(SortOrder.valueOf(order.getType()));
 				request.addSort(scriptSortBuilder);
 			} else {

--- a/src/main/java/org/nlpcn/es4sql/query/DefaultQueryAction.java
+++ b/src/main/java/org/nlpcn/es4sql/query/DefaultQueryAction.java
@@ -45,8 +45,18 @@ public class DefaultQueryAction extends QueryAction {
 	//zhongshu-comment 将sql字符串解析后的java对象，转换为es的查询请求对象
 	@Override
 	public SqlElasticSearchRequestBuilder explain() throws SqlParseException {
-//		this.request = client.prepareSearch();//zhongshu-comment conflict
-		//zhongshu-comment 变量request是es搜索请求对象，调用的是es的api，SearchRequestBuilder是es的原生api
+		/*
+		zhongshu-comment 6.1.1.5这个版本和elastic6.1.1这个分支用的是这一行代码
+		但是在本地调试时我的client没有实例化，并没有去连es，所以这行代码会报空指针
+		那就将这行注释掉吧，以后就用下面那行
+		 */
+//		this.request = client.prepareSearch();
+
+		/*
+		zhongshu-comment  6.2.4.1这个版本和master_zhongshu_dev_01用的是这一行代码，虽然client为null，但是下面这行代码并不会报空指针
+							为了在本地调试、执行下文的那些代码获得es的dsl，所以就使用这行代码，暂时将上面哪一行注释掉，上线的时候记得替换掉
+		变量request是es搜索请求对象，调用的是es的api，SearchRequestBuilder是es的原生api
+		 */
 		this.request = new SearchRequestBuilder(client, SearchAction.INSTANCE);
 
 		setIndicesAndTypes();

--- a/src/main/java/org/nlpcn/es4sql/query/ESActionFactory.java
+++ b/src/main/java/org/nlpcn/es4sql/query/ESActionFactory.java
@@ -60,7 +60,7 @@ public class ESActionFactory {
                 else {
                     //zhongshu-comment 先看懂这个分支
                     Select select = new SqlParser().parseSelect(sqlExpr);
-                    //todo 看不懂，测试了好几个常见的sql，都没有进去该方法，那就先不理了，看别的
+                    //todo 看不懂，测试了好几个常见的sql，都没有进去handleSubQueries该方法，那就先不理了，看别的
                     handleSubQueries(client, select);
                     return handleSelect(client, select);
                 }

--- a/src/main/java/org/nlpcn/es4sql/query/ESActionFactory.java
+++ b/src/main/java/org/nlpcn/es4sql/query/ESActionFactory.java
@@ -132,7 +132,6 @@ public class ESActionFactory {
     }
 
     private static SQLExpr toSqlExpr(String sql) {
-
         SQLExprParser parser = new ElasticSqlExprParser(sql); //zhongshu-comment 这个SQLExprParser parser应该就是语法解析器
         SQLExpr expr = parser.expr(); //zhongshu-comment 这个expr应该就是解析sql之后得到的AST了
 

--- a/src/main/java/org/nlpcn/es4sql/query/ESActionFactory.java
+++ b/src/main/java/org/nlpcn/es4sql/query/ESActionFactory.java
@@ -58,7 +58,7 @@ public class ESActionFactory {
                     return ESJoinQueryActionFactory.createJoinAction(client, joinSelect);
                 }
                 else {
-                    //zhongshu-comment 先看懂这个分支
+                    //zhongshu-comment 大部分查询都是走这个分支，先看懂这个分支
                     Select select = new SqlParser().parseSelect(sqlExpr);
                     //todo 看不懂，测试了好几个常见的sql，都没有进去handleSubQueries该方法，那就先不理了，看别的
                     handleSubQueries(client, select);

--- a/src/main/java/org/nlpcn/es4sql/query/QueryAction.java
+++ b/src/main/java/org/nlpcn/es4sql/query/QueryAction.java
@@ -88,7 +88,8 @@ public abstract class QueryAction {
         }
     }
 
-    protected HighlightBuilder.Field parseHighlightField(Object[] params) {
+    protected HighlightBuilder.Field parseHighlightField(Object[] params)
+    {
         if (params == null || params.length == 0 || params.length > 2) {
             //todo: exception.
         }

--- a/src/main/java/org/nlpcn/es4sql/query/ShowQueryAction.java
+++ b/src/main/java/org/nlpcn/es4sql/query/ShowQueryAction.java
@@ -25,15 +25,7 @@ public class ShowQueryAction extends QueryAction {
         String indexName = sql.split(" ")[1];
         final GetIndexRequestBuilder  indexRequestBuilder ;
         String type = null;
-        if (indexName.startsWith("<")) {
-            if (!indexName.endsWith(">")) {
-                int index = indexName.lastIndexOf('/');
-                if (-1 < index) {
-                    type = indexName.substring(index + 1);
-                    indexName = indexName.substring(0, index);
-                }
-            }
-        } else if (indexName.contains("/")) {
+        if (indexName.contains("/")) {
             String[] indexAndType = indexName.split("\\/");
             indexName = indexAndType[0];
             type = indexAndType[1];

--- a/src/main/java/org/nlpcn/es4sql/query/maker/AggMaker.java
+++ b/src/main/java/org/nlpcn/es4sql/query/maker/AggMaker.java
@@ -293,7 +293,6 @@ public class AggMaker {
         String aggName = gettAggNameFromParamsOrAlias(field);
         TermsAggregationBuilder terms = AggregationBuilders.terms(aggName);
         String value = null;
-        IncludeExclude include = null, exclude = null;
         for (KVValue kv : field.getParams()) {
             value = kv.value.toString();
             switch (kv.key.toLowerCase()) {
@@ -326,30 +325,10 @@ public class AggMaker {
                 case "reverse_nested":
                 case "children":
                     break;
-                case "execution_hint":
-                    terms.executionHint(value);
-                    break;
-                case "include":
-                    try (XContentParser parser = JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY, value)) {
-                        parser.nextToken();
-                        include = IncludeExclude.parseInclude(parser);
-                    } catch (IOException e) {
-                        throw new SqlParseException("parse include[" + value + "] error: " + e.getMessage());
-                    }
-                    break;
-                case "exclude":
-                    try (XContentParser parser = JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY, value)) {
-                        parser.nextToken();
-                        exclude = IncludeExclude.parseExclude(parser);
-                    } catch (IOException e) {
-                        throw new SqlParseException("parse exclude[" + value + "] error: " + e.getMessage());
-                    }
-                    break;
                 default:
                     throw new SqlParseException("terms aggregation err or not define field " + kv.toString());
             }
         }
-        terms.includeExclude(IncludeExclude.merge(include, exclude));
         return terms;
     }
 

--- a/src/main/java/org/nlpcn/es4sql/query/maker/Maker.java
+++ b/src/main/java/org/nlpcn/es4sql/query/maker/Maker.java
@@ -182,12 +182,13 @@ public abstract class Maker {
                 zhongshu-comment 调用CaseWhenParser解析将Condition的nameExpr属性对象解析为script query
                 参考了SqlParser.findSelect()方法，看它是如何解析select中的case when字段的
                  */
-                String scriptCode = new CaseWhenParser((SQLCaseExpr) cond.getNameExpr(), null, null).parseCaseWhenInWhere();
+                String scriptCode = new CaseWhenParser((SQLCaseExpr) cond.getNameExpr(), null, null).parseCaseWhenInWhere((Object[]) value);
                 /*
                 todo 参考DefaultQueryAction.handleScriptField() 将上文得到的scriptCode封装为es的Script对象，
                 但又不是完全相同，因为DefaultQueryAction.handleScriptField()是处理select子句中的case when查询，对应es的script_field查询，
                 而此处是处理where子句中的case when查询，对应的是es的script query，具体要看官网文档，搜索关键字是"script query"
                  */
+                System.out.println();
             } else {
                 //todo: value is subquery? here or before
                 values = (Object[]) value;

--- a/src/main/java/org/nlpcn/es4sql/query/maker/Maker.java
+++ b/src/main/java/org/nlpcn/es4sql/query/maker/Maker.java
@@ -184,11 +184,20 @@ public abstract class Maker {
                  */
                 String scriptCode = new CaseWhenParser((SQLCaseExpr) cond.getNameExpr(), null, null).parseCaseWhenInWhere((Object[]) value);
                 /*
-                todo 参考DefaultQueryAction.handleScriptField() 将上文得到的scriptCode封装为es的Script对象，
+                zhongshu-comment
+                参考DefaultQueryAction.handleScriptField() 将上文得到的scriptCode封装为es的Script对象，
                 但又不是完全相同，因为DefaultQueryAction.handleScriptField()是处理select子句中的case when查询，对应es的script_field查询，
                 而此处是处理where子句中的case when查询，对应的是es的script query，具体要看官网文档，搜索关键字是"script query"
+
+                搜索结果如下：
+                1、文档
+                    https://www.elastic.co/guide/en/elasticsearch/reference/6.1/query-dsl-script-query.html
+                2、java api
+                    https://www.elastic.co/guide/en/elasticsearch/client/java-api/6.1/java-specialized-queries.html
                  */
-                System.out.println();
+
+                x = QueryBuilders.scriptQuery(new Script(scriptCode));
+
             } else {
                 //todo: value is subquery? here or before
                 values = (Object[]) value;

--- a/src/main/java/org/nlpcn/es4sql/query/maker/Maker.java
+++ b/src/main/java/org/nlpcn/es4sql/query/maker/Maker.java
@@ -108,13 +108,6 @@ public abstract class Maker {
 			bqb = Paramer.fullParamer(matchPhraseQuery, paramer);
 			break;
 
-        case "multimatchquery":
-        case "multi_match":
-        case "multimatch":
-            paramer = Paramer.parseParamer(value);
-            MultiMatchQueryBuilder multiMatchQuery = QueryBuilders.multiMatchQuery(paramer.value).fields(paramer.fieldsBoosts);
-            bqb = Paramer.fullParamer(multiMatchQuery, paramer);
-            break;
 		default:
 			throw new SqlParseException("it did not support this query method " + value.getMethodName());
 
@@ -236,16 +229,16 @@ public abstract class Maker {
             Object[] termValues = (Object[]) value;
             if(termValues.length == 1 && termValues[0] instanceof SubQueryExpression)
                 termValues = ((SubQueryExpression) termValues[0]).getValues();
-            Object[] termValuesObjects = new Object[termValues.length];
+            String[] termValuesStrings = new String[termValues.length];
             for (int i=0;i<termValues.length;i++){
-                termValuesObjects[i] = parseTermValue(termValues[i]);
+                termValuesStrings[i] = termValues[i].toString();
             }
-            x = QueryBuilders.termsQuery(name,termValuesObjects);
+            x = QueryBuilders.termsQuery(name,termValuesStrings);
         break;
         case NTERM:
         case TERM:
             Object term  =( (Object[]) value)[0];
-            x = QueryBuilders.termQuery(name, parseTermValue(term));
+            x = QueryBuilders.termQuery(name,term.toString());
             break;
         case IDS_QUERY:
             Object[] idsParameters = (Object[]) value;
@@ -342,28 +335,4 @@ public abstract class Maker {
 		return bqb;
 	}
 
-    private Object parseTermValue(Object termValue) {
-        if (termValue instanceof SQLNumericLiteralExpr) {
-            termValue = ((SQLNumericLiteralExpr) termValue).getNumber();
-            if (termValue instanceof BigDecimal || termValue instanceof Double) {
-                termValue = ((Number) termValue).doubleValue();
-            } else if (termValue instanceof Float) {
-                termValue = ((Number) termValue).floatValue();
-            } else if (termValue instanceof BigInteger || termValue instanceof Long) {
-                termValue = ((Number) termValue).longValue();
-            } else if (termValue instanceof Integer) {
-                termValue = ((Number) termValue).intValue();
-            } else if (termValue instanceof Short) {
-                termValue = ((Number) termValue).shortValue();
-            } else if (termValue instanceof Byte) {
-                termValue = ((Number) termValue).byteValue();
-            }
-        } else if (termValue instanceof SQLBooleanExpr) {
-            termValue = ((SQLBooleanExpr) termValue).getValue();
-        } else {
-            termValue = termValue.toString();
-        }
-
-        return termValue;
-    }
 }

--- a/src/main/java/org/nlpcn/es4sql/query/maker/QueryMaker.java
+++ b/src/main/java/org/nlpcn/es4sql/query/maker/QueryMaker.java
@@ -57,13 +57,14 @@ public class QueryMaker extends Maker {
 			addSubQuery(
 					boolQuery,
 					where,
-					(QueryBuilder) make((Condition) where));
+					(QueryBuilder) make((Condition) where) //zhongshu-comment 重点方法 就是这里解析最细粒度的where条件
+			);
 		} else {
 			/*
 			zhongshu-comment select a,b,c as my_c from tbl where a = 1 or b = 2 and (c = 3 or d = 4) or e > 1
 			上面这条sql中的“b = 2 and (c = 3 or d = 4)”这部分会走该分支，
 			因为“b = 2 and (c = 3 or d = 4)”被封装为Where类型的对象，而不是Condition对象
-			对应的具体知识点见：搜索-->es插件开发-->es-sql-->代码阅读-->如何解析where条件
+			对应的具体笔记见：搜索-->es插件开发-->es-sql-->代码阅读-->如何解析where条件
 			 */
 			BoolQueryBuilder subQuery = QueryBuilders.boolQuery();
 

--- a/src/main/resources/plugin-descriptor.properties
+++ b/src/main/resources/plugin-descriptor.properties
@@ -7,7 +7,10 @@ version=${project.version}
 # 插件的名字
 name=${elasticsearch.plugin.name}
 
-# essql插件的主类，应该到时候会注入到es当中，由es管理该类
+site=${elasticsearch.plugin.site}
+
+jvm=${elasticsearch.plugin.jvm}
+
 classname=${elasticsearch.plugin.classname}
 
 java.version=1.8

--- a/src/main/resources/plugin-descriptor.properties
+++ b/src/main/resources/plugin-descriptor.properties
@@ -16,4 +16,4 @@ classname=${elasticsearch.plugin.classname}
 java.version=1.8
 
 # es的版本，ctrl+鼠标点击 可以跳到pom文件看该参数的值
-elasticsearch.version=${elasticsearch.version} 
+elasticsearch.version=${elasticsearch.version}

--- a/src/test/java/com/zhongshu/ZhongshuTest.java
+++ b/src/test/java/com/zhongshu/ZhongshuTest.java
@@ -243,7 +243,7 @@ public class ZhongshuTest {
 
     @Test
     public void testIf() throws SqlParseException, SQLFeatureNotSupportedException{
-        sql = "SELECT IF(t.a=1,'1','2') from t";
+        sql = "select if(name='Joe','hehe','gg') from t_zhongshu_test_hive2es";
         QueryAction qa = ESActionFactory.create(client, sql);
         qa.explain();
     }
@@ -263,5 +263,90 @@ public class ZhongshuTest {
                 "and dt=20180628 group by aid,appid order by count_v desc";
         QueryAction qa = ESActionFactory.create(client, sql);
         qa.explain();
+    }
+
+    @Test
+    public void testBoge() {
+        sql = "select \n" +
+                "dt\n" +
+                ",ad_source\n" +
+                ",CASE WHEN platform_id = 'PC' and os not in ('全部') THEN 'unknown' ELSE os  END AS os\n" +
+                ",platform_id\n" +
+                ",appid\n" +
+                ",bidtype\n" +
+                ",adslotid\n" +
+                ",adposition_name\n" +
+                ",adpostion_type\n" +
+                ",is_effect\n" +
+                ",theo_inv\n" +
+                ",v_num\n" +
+                ",av_num\n" +
+                ",click_num\n" +
+                ",charge\n" +
+                ",av_stock\n" +
+                ",av_stock_real\n" +
+                ",v_rate\n" +
+                ",av_rate\n" +
+                ",ctr1\n" +
+                ",ctr2\n" +
+                ",ecpm1\n" +
+                ",ecpm2\n" +
+                ",acp\n" +
+                ",case when theo_inv>v_num_high then 0 else theo_inv-v_num_high end as bid_inv\n" +
+                ",v_num_high\n" +
+                ",av_num_high\n" +
+                ",click_num_high\n" +
+                ",av_stock_tail\n" +
+                ",av_stock_tail_real\n" +
+                ",v_num_tail\n" +
+                ",av_num_tail\n" +
+                ",click_num_tail\n" +
+                ",ctr_tail\n" +
+                ",charge_tail\n" +
+                ",ecpm_tail\n" +
+                ",acp_tail\n" +
+                "from\n" +
+                "t_md_xps2_report_consume_video\n" +
+                "where dt>='2018-09-03' and dt<='2018-09-03' and ssp_id not in ('全部','媒体')";
+    }
+
+    @Test
+    public void testBoge2() {
+        sql = "SELECT dt, ad_source\n" +
+                "\t, CASE \n" +
+                "\t\tWHEN platform_id = 'PC'\n" +
+                "\t\tAND os NOT IN ('全部') THEN 'unknown'\n" +
+                "\t\tELSE os\n" +
+                "\tEND AS os, platform_id, appid, bidtype, adslotid\n" +
+                "\t, adposition_name, adpostion_type, is_effect, theo_inv, v_num\n" +
+                "\t, av_num, click_num, charge, av_stock, av_stock_real\n" +
+                "\t, v_rate, av_rate, ctr1, ctr2, ecpm1\n" +
+                "\t, ecpm2, acp\n" +
+                "\t, CASE \n" +
+                "\t\tWHEN theo_inv <= v_num_high THEN 0\n" +
+                "\t\tELSE theo_inv - v_num_high\n" +
+                "\tEND AS bid_inv, v_num_high, av_num_high, click_num_high, av_stock_tail\n" +
+                "\t, av_stock_tail_real, v_num_tail, av_num_tail, click_num_tail, ctr_tail\n" +
+                "\t, charge_tail, ecpm_tail, acp_tail\n" +
+                "FROM t_md_xps2_report_consume_video\n" +
+                "WHERE (dt >= '2018-09-04'\n" +
+                "\tAND dt <= '2018-09-04'\n" +
+                "\tAND ssp_id NOT IN ('全部', '媒体')\n" +
+                "\tAND 1 = 1\n" +
+                "\tAND ad_source NOT IN ('all', '全部')\n" +
+                "\tAND os = '全部'\n" +
+                "\tAND platform_id IN ('全部')\n" +
+                "\tAND appid IN ('全部')\n" +
+                "\tAND bidtype IN ('全部')\n" +
+                "\tAND adslotid IN ('全部')\n" +
+                "\tAND adpostion_type = '全部'\n" +
+                "\tAND is_effect NOT IN ('all', '全部'))\n" +
+                "ORDER BY dt DESC, CASE \n" +
+                "\tWHEN platform_id = 'PC'\n" +
+                "\tAND os NOT IN ('全部') THEN 'unknown'\n" +
+                "\tELSE os\n" +
+                "END ASC, platform_id DESC, appid ASC, ssp_id DESC, charge DESC\n" +
+                "LIMIT 0, 10";
+        System.out.println(sql);
     }
 }

--- a/src/test/java/com/zhongshu/ZhongshuTest.java
+++ b/src/test/java/com/zhongshu/ZhongshuTest.java
@@ -260,7 +260,7 @@ public class ZhongshuTest {
                 "sum(count_click) as count_click,\n" +
                 "sum(sum_charge) as sum_charge \n" +
                 "FROM t_fact_tracking_charge where 1=1 and appid in ('news','newssdk','wapnews','pcnews','tv','h5tv','pctv','union','wapunion','squirrel')\n" +
-                "and dt=20180628 group by aid order by count_v desc";
+                "and dt=20180628 group by aid,appid order by count_v desc";
         QueryAction qa = ESActionFactory.create(client, sql);
         qa.explain();
     }

--- a/src/test/java/com/zhongshu/ZhongshuTest.java
+++ b/src/test/java/com/zhongshu/ZhongshuTest.java
@@ -179,7 +179,7 @@ public class ZhongshuTest {
 
     @Test
     public void testInJudge() throws SqlParseException, SQLFeatureNotSupportedException {
-        sql = "select dt, case when a in ('1', '2', '3') then 'hehe' else 'gg' end as a from tbl";
+        sql = "select dt, case when a in ('1', '2', '3') then 'hehe' when b=2 then 'haha' when c not in (7,8,9) then 'book' else 'gg' end as a from tbl";
         QueryAction qa = ESActionFactory.create(client, sql);
         qa.explain();
     }

--- a/src/test/java/com/zhongshu/ZhongshuTest.java
+++ b/src/test/java/com/zhongshu/ZhongshuTest.java
@@ -179,7 +179,15 @@ public class ZhongshuTest {
 
     @Test
     public void testInJudge() throws SqlParseException, SQLFeatureNotSupportedException {
-        sql = "select dt, case when a in ('1', '2', '3') then 'hehe' when b=2 then 'haha' when c not in (7,8,9) then 'book' else 'gg' end as a from tbl";
+//        sql = "select dt, case when a in ('1', '2', '3') then 'hehe' when b=2 then 'haha' when c not in (7,8,9) then 'book' else 'gg' end as a from tbl";
+        sql = "select dt,case when os in ('Android', 'iOS') then 'hello' else 'world' end abc from t_zhongshu_test";
+        QueryAction qa = ESActionFactory.create(client, sql);
+        qa.explain();
+    }
+
+    @Test
+    public void testRound() throws SqlParseException, SQLFeatureNotSupportedException {
+        sql = "SELECT round(av_num/v_num,4) as av_rate1 FROM t_md_xps2_all_inv_consume_report WHERE dt = '2018-06-14' limit 100";
         QueryAction qa = ESActionFactory.create(client, sql);
         qa.explain();
     }

--- a/src/test/java/com/zhongshu/ZhongshuTest.java
+++ b/src/test/java/com/zhongshu/ZhongshuTest.java
@@ -363,7 +363,7 @@ public class ZhongshuTest {
     @Test
     public void testSongge() {
         //zhongshu-comment 原始的sql
-        /*
+
         sql = "SELECT dt\n" +
                 "\t, CASE \n" +
                 "\t\tWHEN platform_id = 'PC'\n" +
@@ -424,7 +424,9 @@ public class ZhongshuTest {
                 "\tELSE os\n" +
                 "END ASC, platform_id DESC, appid ASC, ssp_id DESC, theo_inv DESC\n" +
                 "LIMIT 0, 10";
-                */
+        System.out.println();
+
+        /*
         sql = "SELECT CASE \n" +
                 "\t\tWHEN platform_id = 'PC'\n" +
                 "\t\tAND os NOT IN ('全部') THEN 'unknown'\n" +
@@ -438,5 +440,54 @@ public class ZhongshuTest {
                 "\t\tELSE os\n" +
                 "\tEND NOT IN ('Android', 'iOS', 'WP')\n" +
                 "LIMIT 0, 10";
+                */
+    }
+
+    @Test
+    public void testSongge2(){
+        sql = "SELECT SUM(CASE \n" +
+                "\t\tWHEN (ett = 'v'\n" +
+                "\t\tAND bidtype = '2'\n" +
+                "\t\tAND priority_f = 'p_70_75'\n" +
+                "\t\tAND accounttype = '1') THEN sum_charge\n" +
+                "\t\tWHEN (ett = 'av'\n" +
+                "\t\tAND bidtype = '4'\n" +
+                "\t\tAND ac_20 = '1'\n" +
+                "\t\tAND priority_f = 'p_70_75'\n" +
+                "\t\tAND accounttype = '1') THEN sum_charge\n" +
+                "\t\tWHEN (ett = 'click'\n" +
+                "\t\tAND bidtype = '3'\n" +
+                "\t\tAND priority_f = 'p_70_75'\n" +
+                "\t\tAND accounttype = '1') THEN sum_charge\n" +
+                "\t\tELSE 0\n" +
+                "\tEND) AS sum_charge, SUM(CASE \n" +
+                "\t\tWHEN ett = 'v' THEN count_num\n" +
+                "\t\tELSE 0\n" +
+                "\tEND) AS v\n" +
+                "\t, SUM(CASE \n" +
+                "\t\tWHEN ett = 'av' THEN count_num\n" +
+                "\t\tELSE 0\n" +
+                "\tEND) AS total_av, SUM(CASE \n" +
+                "\t\tWHEN ett = 'av'\n" +
+                "\t\tAND ac_20 = '1' THEN count_num\n" +
+                "\t\tELSE 0\n" +
+                "\tEND) AS count_av\n" +
+                "\t, SUM(CASE \n" +
+                "\t\tWHEN ett = 'click' THEN count_num\n" +
+                "\t\tELSE 0\n" +
+                "\tEND) AS count_click, SUM(CASE \n" +
+                "\t\tWHEN ett = 'na' THEN count_num\n" +
+                "\t\tELSE 0\n" +
+                "\tEND) AS na\n" +
+                "\t, SUM(CASE \n" +
+                "\t\tWHEN ett = 'naa' THEN count_num\n" +
+                "\t\tELSE 0\n" +
+                "\tEND) AS naa, aid, adslotid\n" +
+                "\t, appid, bidtype, priority_f, accounttype\n" +
+                "FROM t_xps2_track_stream_aid_d\n" +
+                "WHERE 1 = 1\n" +
+                "\tAND dt = 20181018\n" +
+                "GROUP BY adslotid, aid, appid, accounttype, priority_f, bidtype\n" +
+                "LIMIT 10000000";
     }
 }

--- a/src/test/java/com/zhongshu/ZhongshuTest.java
+++ b/src/test/java/com/zhongshu/ZhongshuTest.java
@@ -490,4 +490,12 @@ public class ZhongshuTest {
                 "GROUP BY adslotid, aid, appid, accounttype, priority_f, bidtype\n" +
                 "LIMIT 10000000";
     }
+
+    @Test
+    public void test13(){
+        sql = "SELECT COUNT(*) FROM elasticsearch-sql_test_index_account/account \n" +
+                "GROUP BY \n" +
+                "\tgender, \n" +
+                "\tterms('alias'='ageAgg','field'='age','size'=3)";
+    }
 }

--- a/src/test/java/com/zhongshu/ZhongshuTest.java
+++ b/src/test/java/com/zhongshu/ZhongshuTest.java
@@ -436,7 +436,7 @@ public class ZhongshuTest {
                 "\t\tWHEN platform_id = 'PC'\n" +
                 "\t\tAND os NOT IN ('全部') THEN 'unknown'\n" +
                 "\t\tELSE os\n" +
-                "\tEND IN ('Android')\n" +
+                "\tEND NOT IN ('Android', 'iOS', 'WP')\n" +
                 "LIMIT 0, 10";
     }
 }

--- a/src/test/java/com/zhongshu/ZhongshuTest.java
+++ b/src/test/java/com/zhongshu/ZhongshuTest.java
@@ -191,4 +191,77 @@ public class ZhongshuTest {
         QueryAction qa = ESActionFactory.create(client, sql);
         qa.explain();
     }
+
+    @Test
+    public void testStringOrderBy() throws SQLFeatureNotSupportedException, SqlParseException {
+        sql = "SELECT dt\n" +
+                "\t, CASE\n" +
+                "\t\tWHEN data_source = '0' THEN '新品算'\n" +
+                "\t\tWHEN data_source = '1' THEN '汇算'\n" +
+                "\t\tELSE data_source\n" +
+                "\tEND AS data_source, os, platform_id, ssp_id, adslotid\n" +
+                "\t, adposition_name, ad_source, appid, appdelaytrack, bidtype\n" +
+                "\t, stock, v_num, av_num, click_num\n" +
+                "\t, CASE\n" +
+                "\t\tWHEN ad_source = '中长尾' THEN charge\n" +
+                "\t\tELSE '-'\n" +
+                "\tEND AS charge, av_stock, v_rate, av_rate, ctr1\n" +
+                "\t, ctr2\n" +
+                "\t, CASE\n" +
+                "\t\tWHEN ad_source = '中长尾' THEN ecpm1\n" +
+                "\t\tELSE '-'\n" +
+                "\tEND AS ecpm1\n" +
+                "\t, CASE\n" +
+                "\t\tWHEN ad_source = '中长尾' THEN ecpm2\n" +
+                "\t\tELSE '-'\n" +
+                "\tEND AS ecpm2\n" +
+                "\t, CASE\n" +
+                "\t\tWHEN ad_source = '中长尾' THEN acp\n" +
+                "\t\tELSE '-'\n" +
+                "\tEND AS acp\n" +
+                "FROM t_md_xps2_all_inv_consume_report_v2\n" +
+                "WHERE dt >= '2018-05-20'\n" +
+                "AND dt <= '2018-06-19'\n" +
+                "AND 1 = 1\n" +
+                "AND data_source NOT IN ('all', '全部')\n" +
+                "AND ad_source = '全部'\n" +
+                "AND os = '全部'\n" +
+                "AND appdelaytrack = '全部'\n" +
+                "AND platform_id = '全部'\n" +
+                "AND appid = '全部'\n" +
+                "AND ssp_id = '全部'\n" +
+                "AND bidtype = '全部'\n" +
+                "AND adslotid IN ('全部')\n" +
+                "ORDER BY dt DESC, CASE\n" +
+                "\tWHEN data_source = '0' THEN '新品算'\n" +
+                "\tWHEN data_source = '1' THEN '汇算'\n" +
+                "\tELSE data_source\n" +
+                "END ASC";
+        QueryAction qa = ESActionFactory.create(client, sql);
+        qa.explain();
+    }
+
+    @Test
+    public void testIf() throws SqlParseException, SQLFeatureNotSupportedException{
+        sql = "SELECT IF(t.a=1,'1','2') from t";
+        QueryAction qa = ESActionFactory.create(client, sql);
+        qa.explain();
+    }
+
+    @Test
+    public void testGroupBySize() throws SQLFeatureNotSupportedException, SqlParseException {
+        sql = "SELECT \n" +
+                "aid,\n" +
+                "appid,\n" +
+                "accounttype,\n" +
+                "(case when bidtype='1' then 'CPD' when bidtype='2' then 'CPM' when bidtype='3' then 'CPC' when bidtype='4' then 'DCPM' else '其它' end ) as bidtype,\n" +
+                "sum(count_v) as count_v,\n" +
+                "sum(count_av) as count_av,\n" +
+                "sum(count_click) as count_click,\n" +
+                "sum(sum_charge) as sum_charge \n" +
+                "FROM t_fact_tracking_charge where 1=1 and appid in ('news','newssdk','wapnews','pcnews','tv','h5tv','pctv','union','wapunion','squirrel')\n" +
+                "and dt=20180628 group by aid order by count_v desc";
+        QueryAction qa = ESActionFactory.create(client, sql);
+        qa.explain();
+    }
 }

--- a/src/test/java/org/nlpcn/es4sql/ExplainTest.java
+++ b/src/test/java/org/nlpcn/es4sql/ExplainTest.java
@@ -74,7 +74,7 @@ public class ExplainTest {
     @Test
     public void orderByOnNestedFieldTest() throws Exception {
         String result = explain(String.format("SELECT * FROM %s ORDER BY NESTED('message.info','message')", TEST_INDEX_NESTED_TYPE));
-        assertThat(result.replaceAll("\\s+", ""), equalTo("{\"from\":0,\"size\":200,\"sort\":[{\"message.info\":{\"order\":\"asc\",\"nested\":{\"path\":\"message\"}}}]}"));
+        assertThat(result.replaceAll("\\s+", ""), equalTo("{\"from\":0,\"size\":1000,\"sort\":[{\"message.info\":{\"order\":\"asc\",\"nested\":{\"path\":\"message\"}}}]}"));
     }
 
 

--- a/src/test/java/org/nlpcn/es4sql/ExplainTest.java
+++ b/src/test/java/org/nlpcn/es4sql/ExplainTest.java
@@ -27,7 +27,7 @@ public class ExplainTest {
     @Test
     public void aggregationQuery() throws IOException, SqlParseException, NoSuchMethodException, IllegalAccessException, SQLFeatureNotSupportedException, InvocationTargetException {
         String expectedOutput = Files.toString(new File("src/test/resources/expectedOutput/aggregation_query_explain.json"), StandardCharsets.UTF_8).replaceAll("\r","");
-        String result = explain(String.format("SELECT a, CASE WHEN gender='0' then 'aaa' else 'bbb'end a2345,count(c) FROM %s GROUP BY terms('field'='a','execution_hint'='global_ordinals'),a2345", TEST_INDEX_ACCOUNT));
+        String result = explain(String.format("SELECT a, CASE WHEN gender='0' then 'aaa' else 'bbb'end a2345,count(c) FROM %s GROUP BY terms('field'='a'),a2345", TEST_INDEX_ACCOUNT));
 
         assertThat(result.replaceAll("\\s+",""), equalTo(expectedOutput.replaceAll("\\s+","")));
     }
@@ -77,21 +77,8 @@ public class ExplainTest {
         assertThat(result.replaceAll("\\s+", ""), equalTo("{\"from\":0,\"size\":200,\"sort\":[{\"message.info\":{\"order\":\"asc\",\"nested\":{\"path\":\"message\"}}}]}"));
     }
 
-    @Test
-    public void multiMatchQuery() throws IOException, SqlParseException, SQLFeatureNotSupportedException {
-        String expectedOutput = Files.toString(new File("src/test/resources/expectedOutput/multi_match_query.json"), StandardCharsets.UTF_8).replaceAll("\r", "");
-        String result = explain(String.format("SELECT * FROM %s WHERE q=multimatch(query='this is a test',fields='subject^3,message',analyzer='standard',type='best_fields',boost=1.0,slop=0,tie_breaker=0.3,operator='and')", TEST_INDEX_ACCOUNT));
-        assertThat(result.replaceAll("\\s+", ""), equalTo(expectedOutput.replaceAll("\\s+", "")));
-    }
 
-    @Test
-    public void termsIncludeExcludeExplainTest() throws IOException, SqlParseException, SQLFeatureNotSupportedException {
-        System.out.println(explain("SELECT * FROM index GROUP BY terms(field='correspond_brand_name',size='10',alias='correspond_brand_name',include='\".*sport.*\"',exclude='\"water_.*\"')"));
-        System.out.println(explain("SELECT * FROM index GROUP BY terms(field='correspond_brand_name',size='10',alias='correspond_brand_name',include='[\"mazda\", \"honda\"]',exclude='[\"rover\", \"jensen\"]')"));
-        System.out.println(explain("SELECT * FROM index GROUP BY terms(field='correspond_brand_name',size='10',alias='correspond_brand_name',include='{\"partition\":0,\"num_partitions\":20}')"));
-    }
-
-    private String explain(String sql) throws SQLFeatureNotSupportedException, SqlParseException {
+    private String explain(String sql) throws SQLFeatureNotSupportedException, SqlParseException, InvocationTargetException, NoSuchMethodException, IllegalAccessException, IOException {
         SearchDao searchDao = MainTestSuite.getSearchDao();
         SqlElasticRequestBuilder requestBuilder = searchDao.explain(sql).explain();
         return requestBuilder.explain();

--- a/src/test/resources/expectedOutput/aggregation_query_explain.json
+++ b/src/test/resources/expectedOutput/aggregation_query_explain.json
@@ -23,14 +23,13 @@
         }
     },
     "aggregations" : {
-        "terms(field=a,execution_hint=global_ordinals)" : {
+        "terms(field=a)" : {
             "terms" : {
                 "field" : "a",
                 "size" : 10,
                 "min_doc_count" : 1,
                 "shard_min_doc_count" : 0,
                 "show_term_doc_count_error" : false,
-                "execution_hint": "global_ordinals",
                 "order" : [
                     {
                         "_count" : "desc"

--- a/src/test/resources/expectedOutput/aggregation_query_explain.json
+++ b/src/test/resources/expectedOutput/aggregation_query_explain.json
@@ -46,7 +46,8 @@
                             "source" : "if((doc['gender'].value=='0')){'aaa'} else {'bbb'}",
                             "lang" : "painless"
                         },
-                        "size" : 10,
+                        "size":1000,
+                        "shard_size":20000,
                         "min_doc_count" : 1,
                         "shard_min_doc_count" : 0,
                         "show_term_doc_count_error" : false,

--- a/src/test/resources/expectedOutput/between_query.json
+++ b/src/test/resources/expectedOutput/between_query.json
@@ -1,6 +1,6 @@
 {
     "from" : 0,
-    "size" : 200,
+    "size" : 1000,
     "_source" : {
         "includes" : [
             "cust_code"

--- a/src/test/resources/expectedOutput/script_value.json
+++ b/src/test/resources/expectedOutput/script_value.json
@@ -1,6 +1,6 @@
 {
     "from" : 0,
-    "size" : 200,
+    "size" : 1000,
     "_source" : {
         "includes" : [
             "cust_code"

--- a/src/test/resources/expectedOutput/search_explain.json
+++ b/src/test/resources/expectedOutput/search_explain.json
@@ -47,7 +47,8 @@
         "gender" : {
             "terms" : {
                 "field" : "gender",
-                "size" : 200,
+                "size":1000,
+                "shard_size":20000,
                 "min_doc_count" : 1,
                 "shard_min_doc_count" : 0,
                 "show_term_doc_count_error" : false,

--- a/src/test/resources/expectedOutput/search_explain_filter.json
+++ b/src/test/resources/expectedOutput/search_explain_filter.json
@@ -48,7 +48,8 @@
         "gender" : {
             "terms" : {
                 "field" : "gender",
-                "size" : 200,
+                "size":1000,
+                "shard_size":20000,
                 "min_doc_count" : 1,
                 "shard_min_doc_count" : 0,
                 "show_term_doc_count_error" : false,

--- a/src/test/resources/expectedOutput/search_spatial_explain.json
+++ b/src/test/resources/expectedOutput/search_spatial_explain.json
@@ -1,6 +1,6 @@
 {
   "from" : 0,
-  "size" : 200,
+  "size" : 1000,
   "query" : {
       "bool" : {
             "filter" : [


### PR DESCRIPTION
### 说明
1. 所在公司内部使用的是elasticsearch 6.1.1的版本，发现elasticsearch-sql分支elastic6.1.1有些功能没法满足日常查询需求，便fork然后进行扩展
2. 以下新增功能已在线上环境运行数月时间，还没发现问题，但难免有疏漏，如有纰漏还望见谅

### 增加功能

1. 使order by子句中可以使用case when语句
2. 使case when支持in和not in判断
3. round()函数可以指定保留到小数点后第几位
4. 用户可以通过limit 来指定aggregation每个bucket的size
5. 用户可以通过limit 来指定聚合的shard size
6. 可以使用if函数，例如：select if(sex='1','男','女') from t_user;
7. case when子句中可以进行计算，例如：case when 1 = 1 then field_1 + field_2 else 0 end
    就是可以计算field_1 + field_2，之前是不可以的，只能是一个字段值，不能做计算
8. 在where子句中可以使用case when语句