### PR TITLE
Add test for SqlParseException.<init> and ElasticSqlExprParser.primaryRest

### DIFF
--- a/src/test/java/org/nlpcn/es4sql/SqlParserTests.java
+++ b/src/test/java/org/nlpcn/es4sql/SqlParserTests.java
@@ -1207,6 +1207,19 @@ public class SqlParserTests {
         Assert.assertEquals(1000, params[2]);
     }
 
+    @Test
+    public void testExplanCond() throws SqlParseException {
+        try {
+            String query = "select * from x where y  TERM(\'a\')";
+            Select select = parser.parseSelect(((SQLQueryExpr) (queryToExpr(query))));
+            Condition condition = ((Condition) (select.getWhere().getWheres().get(0)));
+            Object[] values = ((Object[]) (condition.getValue()));
+            Assert.fail("testExplanCond should have thrown SqlParseException");
+        } catch (SqlParseException expected) {
+            Assert.assertEquals("err find condition class com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr", expected.getMessage());
+        }
+    }
+
 
 
     private SQLExpr queryToExpr(String query) {


### PR DESCRIPTION
Hey 😊
I want to contribute the following test:

Test that a `org.nlpcn.es4sql.exception.SqlParseException` is thrown when query is `select * from x where y  TERM('a')`.
This tests the methods [`SqlParseException.<init>`](https://github.com/NLPchina/elasticsearch-sql/blob/fa4568feeb16d8eb2654cb91690e3353e5a222c2/src/main/java/org/nlpcn/es4sql/exception/SqlParseException.java#L5) and [`ElasticSqlExprParser.primaryRest`](https://github.com/NLPchina/elasticsearch-sql/blob/fa4568feeb16d8eb2654cb91690e3353e5a222c2/src/main/java/org/nlpcn/es4sql/parse/ElasticSqlExprParser.java#L224).
This test is based on the test [`termWithStringTest`](https://github.com/NLPchina/elasticsearch-sql/blob/fa4568feeb16d8eb2654cb91690e3353e5a222c2/src/test/java/org/nlpcn/es4sql/SqlParserTests.java#L752).

Curious to hear what you think!

Also, is the description I provided of the test helping you to answer to this pull request? Why (not)?

(I wrote this test as part of a research study at TU Delft. [Find out more](https://github.com/lacinoire/lacinoire/blob/main/README.md))